### PR TITLE
fix(ci): unbreak the GitHub Actions workflow

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -2,35 +2,67 @@ name: Django CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main, development]
   pull_request:
-    branches: [ "main" ]
+    branches: [main, development]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10]
+        # Quoted so YAML doesn't read 3.12 as the number 3.12 (which it
+        # would silently truncate to 3.1 and look up a non-existent
+        # Python release). The Docker image ships 3.12.
+        python-version: ["3.12"]
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: haskala
+          POSTGRES_USER: haskala
+          POSTGRES_PASSWORD: haskala
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U haskala -d haskala"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DJANGO_SETTINGS_MODULE: haskala.settings.dev
+      DATABASE_HOST: localhost
+      DATABASE_PORT: "5432"
+      DATABASE_NAME: haskala
+      DATABASE_USER: haskala
+      DATABASE_PASSWORD: haskala
+      SECRET_KEY: ci-insecure-key-only-used-by-the-test-runner
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Run Tests
-      run: |
-        python manage.py test
-    - name: Make migrations
-      run: |
-        python manage.py makemigrations && python manage.py migrate   
-    - name: Run server
-      run: |
-        python manage.py runserver
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install system packages for psycopg2 / Pillow / GeoDjango
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            libpq-dev libjpeg-dev zlib1g-dev libwebp-dev libgdal-dev gdal-bin
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Django tests
+        run: |
+          python manage.py test --noinput --verbosity=2


### PR DESCRIPTION
## Summary

- Python version was the unquoted scalar \`3.10\` which YAML parsed as the number 3.10 and serialised back to \`3.1\`. actions/setup-python then bailed with \"Version 3.1 with arch x64 not found\". Bumped to \`\"3.12\"\` to match the Docker image and the Django 6 / Wagtail 7.4 floor.
- actions/checkout@v3 and actions/setup-python@v3 run on Node.js 20, which GitHub is forcing to Node.js 24. Bumped to @v4 and @v5 respectively.
- Added a postgres:16 service container, the matching DATABASE_* env vars, and the system packages psycopg2 / Pillow / GeoDjango need on ubuntu-latest, so \`manage.py test\` actually runs against a real database.
- Cached pip downloads on the requirements.txt hash.
- Dropped the old \`Make migrations\` and \`Run server\` steps; migrations are already covered by the test runner and \`runserver\` would block CI forever.
- Added \`development\` as a trigger branch.

## Test plan

- [ ] CI run on this PR is green.