### PR TITLE
Release: Places map asset-shadowing fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,9 @@ services:
     image: haskala
     volumes:
       - .:/app
-      # Keep build artifacts produced inside the image from being shadowed
-      # by the bind mount above:
+      # Keep node_modules from being shadowed by the host bind mount —
+      # the image installs them, the host directory is gitignored.
       - /app/node_modules
-      - /app/haskala/static/css
-      - /app/haskala/static/js
       # STATIC_ROOT (per settings.base): /app/static is also where
       # collectstatic writes during the image build; sharing it with nginx
       # via the named volume lets nginx serve those files directly.


### PR DESCRIPTION
Promote development to main.

Single fix on top of #25: the new Places overview map didn't actually render because anonymous compose volumes were shadowing the host static/{css,js} bind mount, so host npm rebuilds never reached the container.

Verified: build (3.12) pass on PR #27.