### PR TITLE
style(typography): serif heading stack

### DIFF
--- a/haskala/static/scss/_variables.scss
+++ b/haskala/static/scss/_variables.scss
@@ -26,19 +26,26 @@ $haskala-oliv:     #d6c07c;
 // TYPOGRAPHY
 // =========================================================
 
-// Modern system-font stack with Open Sans (already shipped) layered
-// on top for the typographic flavour we want. The bell_mtbold display
-// face is kept available via the .font-title utility but is no longer
-// used for every heading on every page.
+// Body text uses Open Sans (already shipped via _fonts.scss) on top
+// of a modern system sans-serif stack. Headings switch to a serif
+// stack — readers expect a serious / scholarly face on a research
+// library, and the system-serif cascade below renders the historical
+// Garamond/Palatino feel on the systems that ship those fonts and
+// degrades to Georgia (very high-quality on-screen) and finally to
+// Times on the rest.
 $font-family-sans-serif: 'open_sansregular',
                          -apple-system, BlinkMacSystemFont,
                          "Segoe UI", Roboto, "Helvetica Neue",
                          Arial, sans-serif;
+$font-family-serif:      'Iowan Old Style', 'Palatino Linotype',
+                         Palatino, 'Source Serif Pro',
+                         Cambria, Georgia, 'Times New Roman',
+                         Times, serif;
 $font-family-base:        $font-family-sans-serif;
 
-$headings-font-family:    $font-family-sans-serif;
-$headings-font-weight:    700;
-$headings-line-height:    1.2;
+$headings-font-family:    $font-family-serif;
+$headings-font-weight:    600;
+$headings-line-height:    1.25;
 
 // =========================================================
 // GLOBAL COLORS (Bootstrap)


### PR DESCRIPTION
Switch headings from the Open Sans stack to a system-serif cascade — Iowan Old Style → Palatino Linotype → Source Serif Pro → Cambria → Georgia → Times. All system fonts, no font-download. Body stays on Open Sans.

Weight bumped down 700 → 600 because serifs at 700 read heavier than the sans did; line-height widens slightly to match.

## Test plan
- [x] manage.py test — 24/24
- [x] / and /books/<slug>/ render with serif H1/H2.