### PR TITLE
chore: remove dead TOC code from SCSS + JS

### DIFF
--- a/haskala/static/js/book_detail.js
+++ b/haskala/static/js/book_detail.js
@@ -2,9 +2,8 @@
 //
 // Hosts the small client-side helpers that live on the entity detail
 // pages (book, person, place):
-//   1. TOC active-link highlighting driven by IntersectionObserver
-//   2. Permalink copy buttons (any element with data-permalink)
-//   3. "Show more" toggle on long text blocks (.detail-clamp)
+//   1. Permalink copy buttons (any element with data-permalink)
+//   2. "Show more" toggle on long text blocks (.detail-clamp)
 //
 // The page template ships this as <script type="module">; we wait for
 // DOMContentLoaded and gracefully exit when the expected DOM nodes are
@@ -12,61 +11,11 @@
 // some of these features.
 
 document.addEventListener("DOMContentLoaded", () => {
-    initTocHighlight();
     initPermalinkButtons();
     initClampToggles();
 });
 
-// ---- 1. TOC active-link highlighting --------------------------------
-
-function initTocHighlight() {
-    const tocLinks = Array.from(document.querySelectorAll(
-        ".book-toc__link, .person-toc__link, .place-toc__link"
-    ));
-    if (tocLinks.length === 0) return;
-    if (typeof IntersectionObserver !== "function") return;
-
-    const sections = tocLinks
-        .map((link) => {
-            const href = link.getAttribute("href") || "";
-            if (!href.startsWith("#")) return null;
-            const id = href.slice(1);
-            const el = document.getElementById(id);
-            return el ? { id, el, link } : null;
-        })
-        .filter(Boolean);
-
-    if (sections.length === 0) return;
-
-    const byId = new Map(sections.map((s) => [s.id, s.link]));
-    const currentlyVisible = new Set();
-
-    const observer = new IntersectionObserver((entries) => {
-        for (const entry of entries) {
-            if (entry.isIntersecting) currentlyVisible.add(entry.target.id);
-            else currentlyVisible.delete(entry.target.id);
-        }
-        // Highlight the first section in document order that's visible.
-        let active = null;
-        for (const section of sections) {
-            if (currentlyVisible.has(section.id)) {
-                active = section.id;
-                break;
-            }
-        }
-        for (const link of byId.values()) link.classList.remove("is-active");
-        if (active) byId.get(active).classList.add("is-active");
-    }, {
-        // Trigger when the section's top is between 80px from the top
-        // and 60% down the viewport. Sticky header sits at the top.
-        rootMargin: "-80px 0px -40% 0px",
-        threshold: 0,
-    });
-
-    for (const section of sections) observer.observe(section.el);
-}
-
-// ---- 2. Permalink copy ----------------------------------------------
+// ---- 1. Permalink copy ----------------------------------------------
 
 function initPermalinkButtons() {
     const buttons = document.querySelectorAll("[data-permalink]");
@@ -126,7 +75,7 @@ function flashLabel(btn, message, ms = 1500) {
     }, ms);
 }
 
-// ---- 3. Show-more clamp ---------------------------------------------
+// ---- 2. Show-more clamp ---------------------------------------------
 
 function initClampToggles() {
     document.querySelectorAll(".detail-clamp").forEach((block) => {

--- a/haskala/static/scss/_book_detail.scss
+++ b/haskala/static/scss/_book_detail.scss
@@ -2,69 +2,8 @@
 //
 // Visual polish for the Book / Person / Place / secondary detail pages.
 // The page templates share BEM-ish class roots so this partial covers
-// all of them: .book-header, .book-toc, .book-section, plus the
-// matching person-/place-/topic-/series-/publisher-/occupation-
-// variants.
-
-// Sticky TOC column. Falls back to plain block on viewports where
-// position:sticky is not honoured (older browsers, print).
-.book-toc-sticky,
-.person-toc-sticky,
-.place-toc-sticky {
-  position: sticky;
-  top: 1.5rem;
-}
-
-// TOC list — keep it quiet so it doesn't compete with the content.
-%detail-toc {
-  .book-toc__heading,
-  .person-toc__heading,
-  .place-toc__heading {
-    letter-spacing: 0.05em;
-  }
-
-  ol {
-    border-left: 2px solid var(--bs-border-color);
-    padding-left: 0.75rem;
-    margin-left: 0.25rem;
-  }
-
-  li {
-    margin-bottom: 0.25rem;
-    line-height: 1.4;
-  }
-
-  a {
-    color: var(--bs-secondary-color);
-    text-decoration: none;
-    font-size: 0.92rem;
-    display: block;
-    padding: 0.15rem 0 0.15rem 0.25rem;
-    border-left: 2px solid transparent;
-    margin-left: -0.95rem;
-    padding-left: 0.7rem;
-    transition: color 120ms ease, border-color 120ms ease;
-
-    &:hover,
-    &:focus {
-      color: var(--bs-primary);
-    }
-
-    // .is-active is toggled by book_detail.js based on which section
-    // is currently in the viewport.
-    &.is-active {
-      color: var(--bs-primary);
-      border-left-color: var(--bs-primary);
-      font-weight: 600;
-    }
-  }
-}
-
-.book-toc,
-.person-toc,
-.place-toc {
-  @extend %detail-toc;
-}
+// all of them: .book-header, .book-section, plus the matching
+// person-/place-/topic-/series-/publisher-/occupation- variants.
 
 // Hero header — give the title some breathing room and de-emphasise
 // secondary lines.
@@ -178,20 +117,4 @@
 .places-map-sticky {
   position: sticky;
   top: 1.5rem;
-}
-
-// Mobile-only floating action button that opens the TOC offcanvas.
-// Hidden on md+; on small screens it lives in the bottom-left so the
-// thumb can reach it without covering the active section heading.
-.book-toc-fab,
-.person-toc-fab,
-.place-toc-fab {
-  position: fixed;
-  left: 1rem;
-  bottom: 1rem;
-  z-index: 1030;
-  border-radius: 999px;
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-  padding: 0.5rem 0.9rem;
-  font-size: 0.875rem;
 }


### PR DESCRIPTION
TOC was removed from the templates a few PRs back; the matching SCSS selectors and the initTocHighlight() JS function lingered. Dead code, but visible noise in the source tree. Cleanup.

## Test plan
- [x] manage.py test — 24/24
- [x] /books/<slug>/, /persons/<slug>/, /places/<slug>/ still render 200