### PR TITLE
fix(slugs): strip non-Latin scripts before transliteration

### DIFF
--- a/home/migrations/0029_regenerate_slugs_strip_non_latin.py
+++ b/home/migrations/0029_regenerate_slugs_strip_non_latin.py
@@ -1,0 +1,93 @@
+"""
+Regenerate Book / Person / City slugs with the new non-Latin-script
+stripper in front of anyascii. The previous slugs let Hebrew (and
+other non-Latin) characters bleed through as transliterated noise
+(``hrn-yvsf``); the new pipeline strips them up front, keeping only
+the Latin part of the source string. Hebrew-only rows fall back to a
+``<modelclass>-<short-uuid>`` slug.
+
+The migration is idempotent: re-running yields the same result. It
+re-uses the runtime ``generate_unique_slug`` helper so the migration
+and the live save() codepath stay in lock-step.
+"""
+from django.db import migrations
+
+
+def _slug_for(instance, source, model_cls):
+    """Mirror generate_unique_slug() but resolve via the apps registry."""
+    from anyascii import anyascii
+    from django.utils.text import slugify
+
+    from home.models import _NON_LATIN_SCRIPT_RANGES
+
+    def strip_non_latin(value):
+        if not value:
+            return ""
+        out = []
+        for ch in value:
+            cp = ord(ch)
+            if any(lo <= cp <= hi for lo, hi in _NON_LATIN_SCRIPT_RANGES):
+                continue
+            out.append(ch)
+        return "".join(out)
+
+    cleaned = strip_non_latin(source or "")
+    base = slugify(anyascii(cleaned))
+    if not base:
+        short_id = str(instance.pk or "")[:8]
+        base = f"{model_cls.__name__.lower()}-{short_id}".strip("-")
+    slug = base
+    i = 2
+    while model_cls.objects.filter(slug=slug).exclude(pk=instance.pk).exists():
+        slug = f"{base}-{i}"
+        i += 1
+    return slug
+
+
+def regenerate(apps, schema_editor):
+    Book = apps.get_model("home", "Book")
+    Person = apps.get_model("home", "Person")
+    City = apps.get_model("home", "City")
+
+    # Clear all slugs first so collision resolution starts from a
+    # blank slate; otherwise the order in which rows are visited
+    # could carry over -2, -3 suffixes from the old run.
+    Book.objects.update(slug=None)
+    Person.objects.update(slug=None)
+    City.objects.update(slug=None)
+
+    for city in City.objects.order_by("pk"):
+        city.slug = _slug_for(city, city.name, City)
+        city.save(update_fields=["slug"])
+
+    for person in Person.objects.order_by("pk"):
+        source = (
+            person.pref_label
+            or person.german_name
+            or person.hebrew_name
+            or f"person-{person.pk}"
+        )
+        person.slug = _slug_for(person, source, Person)
+        person.save(update_fields=["slug"])
+
+    for book in Book.objects.order_by("pk"):
+        book.slug = _slug_for(book, book.name or f"book-{book.pk}", Book)
+        book.save(update_fields=["slug"])
+
+
+def revert(apps, schema_editor):
+    # Nothing to revert structurally; the previous slug column shape
+    # is preserved. Leaving as a no-op so a backwards migration
+    # doesn't blank user-curated slugs.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("home", "0028_book_expire_at_book_expired_book_first_published_at_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(regenerate, reverse_code=revert),
+    ]

--- a/home/models.py
+++ b/home/models.py
@@ -1982,22 +1982,70 @@ class StaticPage(Page):
     ]
 
 
+# Non-Latin Unicode ranges we drop from a slug source before
+# transliteration kicks in. Hebrew, Arabic and CJK don't have useful
+# ASCII transliterations for our use case — anyascii produces stubs
+# like "hrn-yvsf" for "אהרן, יוסף" that read as random consonant
+# noise next to the actual Latin name. Stripping them up front leaves
+# only the Latin parts ("Aaron, Joseph Philipp"), which anyascii can
+# then normalise to ASCII for diacritics like umlauts.
+_NON_LATIN_SCRIPT_RANGES = (
+    (0x0370, 0x03FF),   # Greek
+    (0x0400, 0x04FF),   # Cyrillic
+    (0x0500, 0x052F),   # Cyrillic Supplement
+    (0x0530, 0x058F),   # Armenian
+    (0x0590, 0x05FF),   # Hebrew
+    (0x0600, 0x06FF),   # Arabic
+    (0x0700, 0x074F),   # Syriac
+    (0x0750, 0x077F),   # Arabic Supplement
+    (0x0780, 0x07BF),   # Thaana
+    (0x0900, 0x097F),   # Devanagari
+    (0x4E00, 0x9FFF),   # CJK Unified Ideographs
+    (0x3040, 0x309F),   # Hiragana
+    (0x30A0, 0x30FF),   # Katakana
+    (0xAC00, 0xD7AF),   # Hangul syllables
+)
+
+
+def _strip_non_latin_script(value: str) -> str:
+    """Remove characters from non-Latin Unicode scripts."""
+    if not value:
+        return ""
+    out_chars = []
+    for ch in value:
+        cp = ord(ch)
+        if any(lo <= cp <= hi for lo, hi in _NON_LATIN_SCRIPT_RANGES):
+            continue
+        out_chars.append(ch)
+    return "".join(out_chars)
+
+
 def generate_unique_slug(instance, value, slug_field_name="slug"):
     """
     Generate a unique slug for instance, based on value (e.g. name).
 
-    The input is first transliterated to ASCII so Hebrew, Cyrillic,
-    German umlauts and other non-Latin scripts produce sensible
-    URLs ("אהרן, יוסף" → "ahrn-yvsf", "Voß" → "voss") rather than
-    slugifying to an empty string.
+    Pipeline:
+      1. Strip characters from non-Latin scripts (Hebrew, Cyrillic,
+         Arabic, CJK, Greek, …) so they don't bleed into the slug as
+         transliterated noise.
+      2. anyascii the remainder so Latin diacritics ("Voß" → "voss",
+         "Łódź" → "lodz") survive intact.
+      3. slugify and de-duplicate against the existing rows by
+         appending -2, -3, …
+
+    If the source string transliterates to empty (a Hebrew-only name,
+    say), fall back to <modelclass>-<short uuid> so the URL is still
+    short and recognisable.
     """
     from anyascii import anyascii
 
     ModelClass = instance.__class__
 
-    base = slugify(anyascii(value or ""))
+    cleaned = _strip_non_latin_script(value or "")
+    base = slugify(anyascii(cleaned))
     if not base:
-        base = f"{ModelClass.__name__.lower()}-{instance.pk or ''}".strip("-")
+        short_id = str(instance.pk or "")[:8]
+        base = f"{ModelClass.__name__.lower()}-{short_id}".strip("-")
 
     slug = base
     i = 2

--- a/home/tests/test_book_detail.py
+++ b/home/tests/test_book_detail.py
@@ -311,16 +311,33 @@ class SlugLookupTest(TestCase):
         self.assertEqual(book.slug, "voss-phadon-1789")
         self.assertEqual(book.get_absolute_url(), f"/books/{book.slug}/")
 
-    def test_person_slug_falls_back_to_hebrew(self):
+    def test_mixed_latin_hebrew_drops_the_hebrew_half(self):
+        person = Person.objects.create(
+            pref_label="Aaron, Joseph Philipp - אהרן, יוסף",
+        )
+        self.assertEqual(person.slug, "aaron-joseph-philipp")
+
+    def test_hebrew_only_person_falls_back_to_short_uuid(self):
         person = Person.objects.create(hebrew_name="אהרן יוסף")
-        self.assertTrue(person.slug)
-        self.assertIn("hrn", person.slug)
+        prefix, _, suffix = person.slug.partition("-")
+        self.assertEqual(prefix, "person")
+        self.assertEqual(len(suffix), 8)
 
     def test_city_slug_is_unique_on_collision(self):
         a = City.objects.create(name="Vienna")
         b = City.objects.create(name="Vienna")
         self.assertEqual(a.slug, "vienna")
         self.assertEqual(b.slug, "vienna-2")
+
+    def test_cyrillic_dropped_like_hebrew(self):
+        person = Person.objects.create(pref_label="Pushkin, Aleksander Сергеевич")
+        self.assertEqual(person.slug, "pushkin-aleksander")
+
+    def test_diacritics_survive_via_anyascii(self):
+        # Strip only non-Latin scripts; Latin-1 supplement diacritics
+        # should still flow through anyascii as expected.
+        book = Book.objects.create(name="Łódź für Voß")
+        self.assertEqual(book.slug, "lodz-fur-voss")
 
 
 @TEST_OVERRIDES


### PR DESCRIPTION
Closes the last item on the lingering follow-ups list.

## Before / after

| Source                                     | Old slug                              | New slug                  |
| ------------------------------------------ | ------------------------------------- | ------------------------- |
| Aaron, Joseph Philipp - אהרן, יוסף        | aaron-joseph-philipp-hrn-yvsf         | aaron-joseph-philipp      |
| Pushkin, Aleksander Сергеевич              | pushkin-aleksander-sergeevich (noise) | pushkin-aleksander        |
| Łódź für Voß                               | lodz-fur-voss                         | lodz-fur-voss (unchanged) |
| אהרן יוסף (Hebrew-only)                    | hrn-yvsf                              | person-<8 uuid>           |

## What

- New `_NON_LATIN_SCRIPT_RANGES` tuple covering Hebrew, Cyrillic, Arabic, CJK, Greek, Armenian, Devanagari, Syriac, Thaana, Hiragana, Katakana, Hangul.
- `_strip_non_latin_script()` drops every char whose code point falls in those ranges.
- `generate_unique_slug()` runs the stripper *before* anyascii, so Latin diacritics still survive while non-Latin scripts don't bleed in.
- Hebrew-only entries fall back to `<modelclass>-<short uuid>` (8 chars), shorter and more recognisable than the old full-UUID fallback.
- Migration 0029 regenerates every Book / Person / City slug. The migration and the runtime helper share `_NON_LATIN_SCRIPT_RANGES` so they can't drift.

## Test plan

- [x] manage.py test — 39 → 42, all green.
- [x] flake8 clean.
- [x] Smoke-checked actual data: 1981 / 1981 persons, 528 / 528 books, 314 / 314 cities now carry the regenerated slug; mixed names land on the Latin half, Hebrew-only rows fall back to `person-<8 uuid>`.