### PR TITLE
feat(docker): HASKALA_DATA_DIR + restore-on-init + monthly backups

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -90,7 +90,7 @@ jobs:
           "
 
           bash docker/backups/backup.sh
-          ls -lh "$BACKUP_DIR"/haskala-*.sql.gz
+          ls -lh "$BACKUP_DIR"/daily/haskala-*.sql.gz
 
           # Drop the entire schema so the restore really has to do work.
           psql --host=localhost --username=haskala --dbname=haskala \
@@ -98,6 +98,21 @@ jobs:
                -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 
           bash docker/backups/restore.sh latest
+
+          # Monthly-rollover exercise: re-run the backup with a date
+          # patched to "01" and confirm a monthly/ snapshot lands.
+          mkdir -p /tmp/_datebin
+          cat > /tmp/_datebin/date <<'PATCH'
+          #!/bin/sh
+          case "$*" in
+              *"+%d"*) echo 01 ;;
+              *"+%Y-%m"*) echo 2999-01 ;;
+              *) exec /usr/bin/date "$@" ;;
+          esac
+          PATCH
+          chmod +x /tmp/_datebin/date
+          PATH=/tmp/_datebin:$PATH bash docker/backups/backup.sh
+          ls -lh "$BACKUP_DIR"/monthly/haskala-2999-01.sql.gz
 
           python manage.py shell -c "
           from home.models import Book

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ node_modules/
 # RDF export output (settings.HASKALA_DUMPS_ROOT default location)
 /dumps/
 
+# Persistent host bind-mount for the docker stack (HASKALA_DATA_DIR).
+# Holds backups, fuseki data, initial seed SQL, awstats output etc.
+/data/
+
 # Generated theme assets (built via `npm run build:*` and `npm run copy:icons`)
 haskala/static/css/haskala.css
 haskala/static/css/haskala.css.map

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,26 @@
 # docker-compose.yml
 #
-# Full development stack for the Haskala library platform.
+# Base stack for the Haskala library platform. Production overlays
+# monit / awstats / cron / postfix via docker-compose.prod.yml; for
+# day-to-day dev work this file is enough on its own.
+#
 # Services:
 #   web         - Django/Wagtail application (gunicorn behind nginx)
-#   db          - PostgreSQL 16 seeded from ./haskala.sql on first boot
+#   db          - PostgreSQL 16, restored on first boot from the
+#                 newest dump in ${HASKALA_DATA_DIR}/backups/{daily,
+#                 monthly}/ — or seeded from ${HASKALA_DATA_DIR}/
+#                 initial/haskala.sql when no backup exists.
 #   redis       - cache and django-redis backend
 #   solr        - search index
-#   fuseki      - RDF triple store
-#   mailserver  - MailHog dev SMTP/HTTP UI
+#   fuseki      - persistent TDB2 RDF store at ${HASKALA_DATA_DIR}/fuseki
+#   mailserver  - MailHog dev SMTP/HTTP UI (dev-only; production override
+#                 swaps in a postfix sidecar)
 #   nginx       - reverse proxy in front of web
-#   backups     - scheduled pg_dump of db into the named backups_data volume
+#   backups     - scheduled pg_dump of db into ${HASKALA_DATA_DIR}/
+#                 backups (daily 14d + monthly 12mo)
+#
+# All host-bound state lives under ${HASKALA_DATA_DIR} (default
+# ./data). Override for production with HASKALA_DATA_DIR=/srv/haskala.
 
 services:
   web:
@@ -58,7 +69,13 @@ services:
       POSTGRES_USER: haskala
       POSTGRES_PASSWORD: haskala
     volumes:
-      - ./haskala.sql:/docker-entrypoint-initdb.d/haskala.sql:ro
+      # On a fresh volume the init script auto-loads the newest dump
+      # under /backups/{daily,monthly}/ — falling back to /initial/
+      # haskala.sql when no backup is around. See docker/db-init/
+      # 00-restore-or-seed.sh.
+      - ./docker/db-init:/docker-entrypoint-initdb.d:ro
+      - ${HASKALA_DATA_DIR:-./data}/backups:/backups:ro
+      - ${HASKALA_DATA_DIR:-./data}/initial:/initial:ro
       - postgres_data:/var/lib/postgresql/data/
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U haskala -d haskala"]
@@ -83,10 +100,23 @@ services:
   fuseki:
     image: stain/jena-fuseki
     environment:
-      - ADMIN_PASSWORD=admin
+      - ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD:-admin}
+      # The image's entrypoint creates /fuseki-base/databases/$FUSEKI_DATASET
+      # and starts the server with --tdb2 --update at that location.
+      - FUSEKI_DATASET_1=haskala
     ports:
       - "3030:3030"
-    command: /jena-fuseki/fuseki-server --mem --update /haskala
+    volumes:
+      # /fuseki is the image's FUSEKI_BASE; it carries databases/,
+      # configuration/, backups/ and the shiro.ini auth file. Binding
+      # the whole tree means TDB2 data survives restarts, the named
+      # dataset stays put, and any admin tweaks via the API persist.
+      - ${HASKALA_DATA_DIR:-./data}/fuseki:/fuseki
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3030/$$/ping || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
   mailserver:
     image: mailhog/mailhog
@@ -120,13 +150,13 @@ services:
       POSTGRES_USER: haskala
       POSTGRES_PASSWORD: haskala
       BACKUP_DIR: /backups
-      BACKUP_RETENTION_DAYS: "14"
+      BACKUP_RETENTION_DAYS_DAILY: "14"
+      BACKUP_RETENTION_DAYS_MONTHLY: "365"
       TZ: Europe/Berlin
     volumes:
-      - backups_data:/backups
+      - ${HASKALA_DATA_DIR:-./data}/backups:/backups
     restart: unless-stopped
 
 volumes:
   postgres_data:
   static_data:
-  backups_data:

--- a/docker/backups/backup.sh
+++ b/docker/backups/backup.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 #
-# Take a timestamped, gzipped pg_dump of the Haskala database and
-# prune dumps older than BACKUP_RETENTION_DAYS.
+# Take a timestamped, gzipped pg_dump of the Haskala database into
+# $BACKUP_DIR/daily/. On the first day of the month also copy the
+# fresh dump into $BACKUP_DIR/monthly/ as a long-term snapshot.
+# Prune both directories on their own retention windows.
 #
 # Connection is configured via environment variables (see the
 # `backups` service in docker-compose.yml).
@@ -13,12 +15,15 @@ set -euo pipefail
 : "${POSTGRES_DB:=haskala}"
 : "${POSTGRES_USER:=haskala}"
 : "${BACKUP_DIR:=/backups}"
-: "${BACKUP_RETENTION_DAYS:=14}"
+: "${BACKUP_RETENTION_DAYS_DAILY:=14}"
+: "${BACKUP_RETENTION_DAYS_MONTHLY:=365}"
 
-mkdir -p "$BACKUP_DIR"
+daily_dir="${BACKUP_DIR}/daily"
+monthly_dir="${BACKUP_DIR}/monthly"
+mkdir -p "${daily_dir}" "${monthly_dir}"
 
 ts=$(date -u +%Y%m%d-%H%M%S)
-out="$BACKUP_DIR/haskala-${ts}.sql.gz"
+out="${daily_dir}/haskala-${ts}.sql.gz"
 tmp="${out}.partial"
 
 log() { echo "[$(date -u +%FT%TZ)] $*"; }
@@ -26,10 +31,10 @@ log() { echo "[$(date -u +%FT%TZ)] $*"; }
 log "Dumping ${POSTGRES_DB} on ${POSTGRES_HOST}:${POSTGRES_PORT} -> ${out}"
 
 # Stream pg_dump straight into gzip so the uncompressed plain SQL
-# never lands on disk. --format=plain so the file is human-readable
-# and can be piped into psql for restore. --clean --if-exists adds
-# DROP IF EXISTS statements ahead of every CREATE so the dump can be
-# replayed into an already-populated database.
+# never lands on disk. --clean --if-exists adds DROP IF EXISTS
+# statements ahead of every CREATE so the dump can be replayed into
+# an already-populated database or pulled in by 00-restore-or-seed.sh
+# on a fresh data volume.
 PGPASSWORD="${POSTGRES_PASSWORD:-}" pg_dump \
     --host="${POSTGRES_HOST}" \
     --port="${POSTGRES_PORT}" \
@@ -44,10 +49,24 @@ PGPASSWORD="${POSTGRES_PASSWORD:-}" pg_dump \
 
 mv "${tmp}" "${out}"
 
-# Retention: drop dumps older than BACKUP_RETENTION_DAYS. -mtime is in
-# 24-hour multiples relative to "now"; +N matches "older than N days".
-removed=$(find "${BACKUP_DIR}" -maxdepth 1 -name 'haskala-*.sql.gz' \
-    -type f -mtime "+${BACKUP_RETENTION_DAYS}" -print -delete | wc -l)
+# Monthly rollover: on the 1st of the month, make a long-lived copy
+# of today's daily dump under monthly/. Naming uses YYYY-MM so the
+# file is overwriteable in case the cron fires twice (rare; harmless).
+day_of_month=$(date -u +%d)
+if [ "${day_of_month}" = "01" ]; then
+    yyyymm=$(date -u +%Y-%m)
+    monthly="${monthly_dir}/haskala-${yyyymm}.sql.gz"
+    cp -f "${out}" "${monthly}"
+    log "Monthly rollover: copied -> ${monthly}"
+fi
+
+# Retention. -mtime is in 24-hour multiples relative to "now"; +N
+# matches "older than N days". Daily and monthly have separate
+# windows so a month-old monthly stays even when daily is pruned.
+removed_daily=$(find "${daily_dir}" -maxdepth 1 -name 'haskala-*.sql.gz' \
+    -type f -mtime "+${BACKUP_RETENTION_DAYS_DAILY}" -print -delete | wc -l)
+removed_monthly=$(find "${monthly_dir}" -maxdepth 1 -name 'haskala-*.sql.gz' \
+    -type f -mtime "+${BACKUP_RETENTION_DAYS_MONTHLY}" -print -delete | wc -l)
 
 size=$(du -h "${out}" | cut -f1)
-log "Backup complete (${size}); pruned ${removed} dump(s) older than ${BACKUP_RETENTION_DAYS}d"
+log "Backup complete (${size}); pruned ${removed_daily} daily older than ${BACKUP_RETENTION_DAYS_DAILY}d, ${removed_monthly} monthly older than ${BACKUP_RETENTION_DAYS_MONTHLY}d"

--- a/docker/backups/restore.sh
+++ b/docker/backups/restore.sh
@@ -28,16 +28,26 @@ fi
 target="$1"
 
 if [ "${target}" = "latest" ]; then
-    target=$(ls -1t "${BACKUP_DIR}"/haskala-*.sql.gz 2>/dev/null | head -n 1 || true)
+    # Newest across daily/ and monthly/ wins.
+    target=$(ls -1t \
+        "${BACKUP_DIR}"/daily/haskala-*.sql.gz \
+        "${BACKUP_DIR}"/monthly/haskala-*.sql.gz \
+        2>/dev/null | head -n 1 || true)
     if [ -z "${target}" ]; then
-        echo "No backups found in ${BACKUP_DIR}" >&2
+        echo "No backups found under ${BACKUP_DIR}/{daily,monthly}/" >&2
         exit 1
     fi
 fi
 
 # Allow the caller to pass a bare filename or a fully-qualified path.
+# Bare names get resolved against daily/ first, then monthly/.
 if [[ "${target}" != /* ]]; then
-    target="${BACKUP_DIR}/${target}"
+    for candidate in "${BACKUP_DIR}/daily/${target}" "${BACKUP_DIR}/monthly/${target}" "${BACKUP_DIR}/${target}"; do
+        if [ -f "${candidate}" ]; then
+            target="${candidate}"
+            break
+        fi
+    done
 fi
 
 if [ ! -f "${target}" ]; then

--- a/docker/db-init/00-restore-or-seed.sh
+++ b/docker/db-init/00-restore-or-seed.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Runs on the FIRST boot of the postgres container — i.e. when the
+# data volume is empty. Postgres's official image executes every
+# *.sh in /docker-entrypoint-initdb.d/ at that point with PGUSER /
+# PGPASSWORD / PGDATABASE already set to the values from POSTGRES_*
+# env, so we can talk to the local socket without re-authenticating.
+#
+# Logic:
+#   1. Look in /backups/daily/ then /backups/monthly/ for a *.sql.gz.
+#   2. If found: zcat into psql — the dump uses --clean --if-exists
+#      so it replays cleanly into the freshly-created database.
+#   3. Otherwise: replay /initial/haskala.sql if it exists.
+#   4. Otherwise: log and exit 0 — Django migrations will create the
+#      schema on first run.
+#
+# Idempotent by design: the script only fires when the data dir is
+# empty, so a subsequent restart of an already-populated cluster
+# never touches /backups or /initial again.
+
+set -euo pipefail
+
+log() { echo "[$(date -u +%FT%TZ)] restore-or-seed: $*"; }
+
+candidate=""
+if compgen -G "/backups/daily/haskala-*.sql.gz" > /dev/null; then
+    candidate="$(ls -1t /backups/daily/haskala-*.sql.gz | head -n 1)"
+fi
+if [ -z "$candidate" ] && compgen -G "/backups/monthly/haskala-*.sql.gz" > /dev/null; then
+    candidate="$(ls -1t /backups/monthly/haskala-*.sql.gz | head -n 1)"
+fi
+
+if [ -n "$candidate" ]; then
+    log "restoring from $candidate"
+    zcat "$candidate" | psql \
+        --username "$POSTGRES_USER" \
+        --dbname "$POSTGRES_DB" \
+        --quiet \
+        --set ON_ERROR_STOP=1
+    log "restore complete"
+elif [ -f /initial/haskala.sql ]; then
+    log "no backups found; seeding from /initial/haskala.sql"
+    psql \
+        --username "$POSTGRES_USER" \
+        --dbname "$POSTGRES_DB" \
+        --quiet \
+        --set ON_ERROR_STOP=1 \
+        --file /initial/haskala.sql
+    log "seed complete"
+else
+    log "no backups and no /initial/haskala.sql — leaving DB empty for migrations to populate"
+fi

--- a/docs/developers/setup.md
+++ b/docs/developers/setup.md
@@ -11,10 +11,39 @@ cd haskala
 docker compose up -d
 ```
 
-On first boot the `db` container loads `haskala.sql` from the repo
-root, the `web` container runs `python manage.py migrate`, and nginx
-proxies <http://localhost:8080/> to gunicorn. Solr, Redis, Fuseki and
-MailHog come up alongside.
+On first boot the `db` container runs
+`docker/db-init/00-restore-or-seed.sh` against the (empty) postgres
+data volume. The script:
+
+1. looks for the newest dump in `${HASKALA_DATA_DIR}/backups/daily/`,
+   then `monthly/`, and restores it via `psql`;
+2. if no backup exists, falls back to
+   `${HASKALA_DATA_DIR}/initial/haskala.sql`;
+3. if neither exists, leaves the database empty for `manage.py
+   migrate` to populate.
+
+`HASKALA_DATA_DIR` defaults to `./data`; set it via `.env` to point at
+a production location like `/srv/haskala`. After the DB is ready the
+`web` container runs `python manage.py migrate`, nginx proxies
+<http://localhost:8080/> to gunicorn, and Solr, Redis, Fuseki (persistent
+TDB2 at `${HASKALA_DATA_DIR}/fuseki/`) and MailHog come up alongside.
+
+The `backups` service runs a daily `pg_dump` at 02:30 UTC into
+`${HASKALA_DATA_DIR}/backups/daily/` (kept 14 days). On the first day of
+the month it additionally drops a monthly snapshot under
+`${HASKALA_DATA_DIR}/backups/monthly/` (kept 365 days). Force a backup
+at any time with:
+
+```bash
+docker compose exec backups /usr/local/bin/backup.sh
+```
+
+Restore the latest dump (across daily + monthly) into the running DB
+with:
+
+```bash
+docker compose exec backups /usr/local/bin/restore.sh latest
+```
 
 A superuser:
 


### PR DESCRIPTION
Groundwork PR for the production-shaped cluster. All host-bound state moves under one configurable root `${HASKALA_DATA_DIR}` (default `./data`). Postgres restores the newest *.sql.gz on first boot instead of always replaying the in-repo seed. Fuseki gets persistent TDB2. Backups grow a monthly/ rollover.

See the PR diff and `docs/developers/setup.md` for the full layout.

## Test plan
- [x] manage.py test 42/42 + flake8 clean
- [x] Existing postgres_data volume keeps working — 528 books still visible on `/books/`
- [x] Fresh volume + daily/ present → restore-or-seed restores the newest dump (verified)
- [x] Fresh volume + only initial/haskala.sql → seed path fires (verified)
- [x] Fuseki: GSP-loaded triples survive `docker compose restart fuseki` (verified)
- [x] backup.sh writes to /backups/daily/; faked day=01 also writes to /backups/monthly/
- [x] restore.sh latest picks the newest file across daily+monthly
- [x] CI "Backup + restore smoke test" extended for the monthly-rollover branch

## What's next (PR-B + PR-C)
- PR-B: docker-compose.prod.yml with postfix sidecar, monit, awstats, cron container
- PR-C: nginx /awstats/ + /monit/ proxy locations, settings tweaks for postfix routing, .env.example