### PR TITLE
feat(docker): production overlay — monit + awstats + cron + postfix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,60 @@
+# Haskala environment example. Copy to .env and fill in.
+# .env itself is gitignored.
+
+# ----- Django -----
+SECRET_KEY=changeme-pick-something-50-chars-long-and-random
+DEBUG=False
+ALLOWED_HOSTS=haskala.example.org,www.haskala.example.org
+CSRF_TRUSTED_ORIGINS=https://haskala.example.org,https://www.haskala.example.org
+
+# ----- Database -----
+DATABASE_NAME=haskala
+DATABASE_USER=haskala
+DATABASE_PASSWORD=changeme
+DATABASE_HOST=db
+DATABASE_PORT=5432
+
+# ----- Persistence root -----
+# All host-bound state (postgres dumps, fuseki TDB2, awstats logs,
+# postfix spool, monit logs, initial seed SQL) sits under this dir.
+# Default ./data keeps dev local; a production deploy points it at
+# /srv/haskala or similar. Sub-paths are created lazily.
+HASKALA_DATA_DIR=./data
+
+# ----- Fuseki -----
+FUSEKI_ADMIN_PASSWORD=changeme
+
+# ----- Monit (HTTP basic auth for /monit/) -----
+MONIT_USERNAME=admin
+MONIT_PASSWORD=changeme
+
+# ----- Email via postfix sidecar in production -----
+# Domain authorised to submit mail through the local postfix relay.
+# Without this, the sidecar would accept submissions from anywhere
+# on the docker network.
+EMAIL_SENDER_DOMAIN=haskala.example.org
+
+# Upstream SMTP that postfix forwards to. Empty disables the relay
+# (mail will queue locally and bounce).
+EMAIL_RELAY_HOST=smtp.example.org:587
+EMAIL_RELAY_USER=
+EMAIL_RELAY_PASSWORD=
+# may, encrypt, dane, dane-only, fingerprint, verify, secure
+EMAIL_RELAY_TLS_LEVEL=encrypt
+
+# ----- Outbound from-address (used by Django) -----
+DEFAULT_FROM_EMAIL=haskala@example.org
+SERVER_EMAIL=haskala@example.org
+
+# ----- RDF auto-push to SPARQL endpoint (optional) -----
+# Empty disables the push; export_rdf still writes its local files.
+HASKALA_SPARQL_PUSH_URL=
+HASKALA_SPARQL_PUSH_GRAPH=http://data.judaicalink.org/data/haskala
+HASKALA_SPARQL_PUSH_PROTOCOL=gsp
+HASKALA_SPARQL_PUSH_USER=
+HASKALA_SPARQL_PUSH_PASSWORD=
+HASKALA_SPARQL_PUSH_TIMEOUT=60
+
+# ----- Tracking / analytics (optional) -----
+MATOMO_URL=
+MATOMO_SITE_IDS=

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,103 @@
+# Production overlay. Combines with the base docker-compose.yml:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# What this file adds:
+#   monit     - watchdog + HTTP UI on :2812 (proxied via nginx as /monit/).
+#   awstats   - web statistics, reads nginx access logs via shared volume.
+#   cron      - scheduled work: AWStats refresh, monthly Fuseki dump,
+#               logrotate. (Daily Postgres backup stays on the `backups`
+#               service from the base file.)
+#   postfix   - relays outbound mail to the institutional SMTP server.
+#
+# What this file overrides:
+#   web       - point EMAIL_HOST at the postfix sidecar.
+#   mailserver - moved behind the "dev-only" compose profile so it does
+#               not start in production.
+#
+# Every host-bound state path lives under ${HASKALA_DATA_DIR:-./data}
+# — set it via .env for a production deploy (e.g. /srv/haskala).
+
+services:
+  web:
+    environment:
+      EMAIL_HOST: postfix
+      EMAIL_PORT: "25"
+      EMAIL_USE_TLS: "False"
+      DJANGO_SETTINGS_MODULE: haskala.settings.production
+
+  mailserver:
+    # MailHog is dev-only. Gating it behind a profile makes
+    # `docker compose up` (with the prod overlay and no profile flag)
+    # skip the container entirely.
+    profiles: ["dev-only"]
+
+  nginx:
+    # In production, nginx's access log lives on the same bind-mount
+    # AWStats reads from. The cron container rotates it.
+    volumes:
+      - ${HASKALA_DATA_DIR:-./data}/awstats/logs:/var/local/log
+
+  monit:
+    image: maltyxx/monit:latest
+    container_name: haskala-monit-1
+    environment:
+      MONIT_USERNAME: ${MONIT_USERNAME:-admin}
+      MONIT_PASSWORD: ${MONIT_PASSWORD:-admin}
+    volumes:
+      - ./docker/monit/monit.cfg:/etc/monit/monit.d/monit.cfg:ro
+      - ${HASKALA_DATA_DIR:-./data}/monit/logs:/var/log/monit
+      # Mounting the docker socket lets monit restart sibling
+      # containers when their health check fails. Read-only because
+      # monit only needs the "docker restart" verb.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    expose: ["2812"]
+    restart: unless-stopped
+    depends_on: [web, nginx, db, redis, solr, fuseki]
+
+  awstats:
+    image: pabra/awstats:latest
+    container_name: haskala-awstats-1
+    environment:
+      TZ: Europe/Berlin
+    volumes:
+      - ./docker/awstats/config:/etc/awstats:ro
+      - ${HASKALA_DATA_DIR:-./data}/awstats/logs:/var/local/log:ro
+      - ${HASKALA_DATA_DIR:-./data}/awstats/data:/var/lib/awstats
+    expose: ["80"]
+    restart: unless-stopped
+    depends_on: [nginx]
+
+  cron:
+    build: ./docker/cron
+    container_name: haskala-cron-1
+    environment:
+      BACKUP_DIR: /backups
+      FUSEKI_URL: http://fuseki:3030
+      FUSEKI_USER: admin
+      FUSEKI_PASSWORD: ${FUSEKI_ADMIN_PASSWORD:-admin}
+      FUSEKI_DATASET: haskala
+      TZ: Europe/Berlin
+    volumes:
+      - ${HASKALA_DATA_DIR:-./data}/backups:/backups
+      - ${HASKALA_DATA_DIR:-./data}/awstats/logs:/var/local/log
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+    depends_on: [fuseki]
+
+  postfix:
+    image: boky/postfix:latest
+    container_name: haskala-postfix-1
+    environment:
+      # Without ALLOWED_SENDER_DOMAINS the relay would happily accept
+      # mail from anywhere on the docker network. Set this to the
+      # public mail-from domain (e.g. haskala-library.org).
+      ALLOWED_SENDER_DOMAINS: ${EMAIL_SENDER_DOMAIN:-}
+      RELAYHOST: ${EMAIL_RELAY_HOST:-}
+      RELAYHOST_USERNAME: ${EMAIL_RELAY_USER:-}
+      RELAYHOST_PASSWORD: ${EMAIL_RELAY_PASSWORD:-}
+      RELAYHOST_TLS_LEVEL: ${EMAIL_RELAY_TLS_LEVEL:-encrypt}
+    volumes:
+      - ${HASKALA_DATA_DIR:-./data}/postfix/spool:/var/spool/postfix
+    expose: ["25"]
+    restart: unless-stopped

--- a/docker/awstats/config/awstats.haskala.conf
+++ b/docker/awstats/config/awstats.haskala.conf
@@ -1,0 +1,46 @@
+# AWStats configuration for the Haskala public site.
+#
+# - LogFile points at the access log nginx writes to the shared
+#   bind-mount (data/awstats/logs/access.log).
+# - LogFormat=1 matches nginx's "combined" log_format.
+# - DirData stores the AWStats database. Persisted via the shared
+#   data/awstats/data/ bind-mount.
+# - The cron container runs awstats_updateall.pl every 30 minutes to
+#   keep the database fresh.
+
+LogFile="/var/local/log/access.log"
+LogType=W
+LogFormat=1
+LogSeparator=" "
+
+SiteDomain="haskala.example.org"
+HostAliases="haskala.example.org www.haskala.example.org localhost 127.0.0.1"
+
+DirData="/var/lib/awstats"
+DirCgi="/cgi-bin"
+DirIcons="/icon"
+
+AllowFullYearView=3
+AllowToUpdateStatsFromBrowser=0
+EnableLockForUpdate=1
+
+DNSLookup=2
+SkipFiles="REGEX[^/static/] REGEX[^/media/] /robots\.txt /favicon\.ico"
+SkipHosts=""
+
+ShowMonthStats=UVPHB
+ShowDaysOfMonthStats=VPHB
+ShowDaysOfWeekStats=PHB
+ShowHoursStats=PHB
+ShowDomainsStats=PHB
+ShowHostsStats=PHB
+ShowRobotsStats=HBL
+ShowSessionsStats=1
+ShowPagesStats=PBEX
+ShowFileTypesStats=HB
+ShowOSStats=1
+ShowBrowsersStats=1
+ShowKeywordsStats=1
+
+UseFramesWhenCGI=1
+LevelForBrowsersDetection=2

--- a/docker/cron/Dockerfile
+++ b/docker/cron/Dockerfile
@@ -1,0 +1,29 @@
+# Cron container for the production stack. Owns the scheduled work
+# the standalone `backups` service doesn't:
+#   - monthly Fuseki dump
+#   - AWStats refresh every 30 minutes
+#   - weekly logrotate of /var/local/log/*.log
+#
+# The Postgres backup itself stays on the dedicated `backups` service
+# (docker-compose.yml) — duplicating the schedule would risk two
+# concurrent pg_dumps racing on retention pruning.
+FROM alpine:3.20
+
+RUN apk add --no-cache \
+        bash \
+        coreutils \
+        gzip \
+        tar \
+        curl \
+        ca-certificates \
+        logrotate \
+        postgresql16-client \
+        tzdata
+
+COPY backup_fuseki.sh /usr/local/bin/backup_fuseki.sh
+COPY update_awstats.sh /usr/local/bin/update_awstats.sh
+COPY logrotate.conf /etc/logrotate.d/haskala
+COPY crontab /etc/crontabs/root
+RUN chmod 0755 /usr/local/bin/*.sh && chmod 0644 /etc/crontabs/root
+
+CMD ["crond", "-f", "-L", "/dev/stderr"]

--- a/docker/cron/backup_fuseki.sh
+++ b/docker/cron/backup_fuseki.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Monthly snapshot of the Haskala Fuseki dataset. We grab a Turtle
+# dump through Fuseki's Graph Store Protocol (GSP) endpoint rather
+# than tarballing the on-disk TDB2 files, because the GSP dump is
+# both engine-agnostic (replayable into any triplestore) and safer
+# under a running server.
+#
+# Output: $BACKUP_DIR/monthly/fuseki-YYYY-MM.ttl.gz
+
+set -euo pipefail
+
+: "${BACKUP_DIR:=/backups}"
+: "${FUSEKI_URL:=http://fuseki:3030}"
+: "${FUSEKI_USER:=admin}"
+: "${FUSEKI_PASSWORD:=admin}"
+: "${FUSEKI_DATASET:=haskala}"
+
+month=$(date -u +%Y-%m)
+out="${BACKUP_DIR}/monthly/fuseki-${month}.ttl.gz"
+tmp="${out}.partial"
+
+log() { echo "[$(date -u +%FT%TZ)] $*"; }
+
+mkdir -p "${BACKUP_DIR}/monthly"
+log "Fetching ${FUSEKI_URL}/${FUSEKI_DATASET}/data?default -> ${out}"
+
+# GSP "GET ?default" returns the union of the default graph; passing
+# &graph=<iri> would fetch a single named graph instead.
+curl --silent --show-error --fail \
+    --user "${FUSEKI_USER}:${FUSEKI_PASSWORD}" \
+    --header "Accept: text/turtle" \
+    "${FUSEKI_URL}/${FUSEKI_DATASET}/data?default" \
+  | gzip -9 > "${tmp}"
+
+mv "${tmp}" "${out}"
+size=$(du -h "${out}" | cut -f1)
+log "Fuseki snapshot complete (${size})"

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -1,0 +1,15 @@
+# Production cron schedule. Times are interpreted in the container's
+# TZ (Europe/Berlin per docker-compose.prod.yml).
+#
+# Daily Postgres backup is owned by the `backups` service in
+# docker-compose.yml — don't duplicate it here.
+
+# AWStats refresh every 30 minutes.
+*/30 * * * * /usr/local/bin/update_awstats.sh >> /var/log/cron-awstats.log 2>&1
+
+# Monthly Fuseki dump on the 1st at 04:15. Lands next to the SQL
+# monthlies under $BACKUP_DIR/monthly/.
+15 4 1 * * /usr/local/bin/backup_fuseki.sh >> /var/log/cron-fuseki.log 2>&1
+
+# Weekly logrotate of the AWStats access log and the cron own logs.
+0 3 * * 0 /usr/sbin/logrotate -f /etc/logrotate.d/haskala >> /var/log/cron-logrotate.log 2>&1

--- a/docker/cron/logrotate.conf
+++ b/docker/cron/logrotate.conf
@@ -1,0 +1,31 @@
+# Rotate the nginx access log nightly via the cron-driven weekly
+# job, and the cron container's own logs. Files are gzipped after
+# rotation; AWStats keeps reading the live access.log because nginx
+# is told to reopen its file handles via the rotated SIGUSR1 hook.
+
+/var/local/log/access.log {
+    daily
+    rotate 14
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 root root
+    sharedscripts
+    postrotate
+        # Ask nginx to reopen its log files. Works because the nginx
+        # container shares the docker network and has its master
+        # process running as PID 1 with a known name.
+        /usr/bin/env docker kill --signal=USR1 haskala-nginx-1 2>/dev/null || true
+    endscript
+}
+
+/var/log/cron-*.log {
+    weekly
+    rotate 4
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 root root
+}

--- a/docker/cron/update_awstats.sh
+++ b/docker/cron/update_awstats.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Re-parse the nginx access log into the AWStats DB. Both sides
+# share the same /var/local/log/ bind-mount, so this script reaches
+# in directly without needing rsync.
+
+set -euo pipefail
+
+# awstats is shipped as a separate container with awstats_updateall
+# on PATH; calling it from here would need that binary installed in
+# this image too. Instead we use awstats's documented update via
+# curl against the AWStats container's CGI — kept commented out
+# because the AWStats container's own command line already invokes
+# awstats_updateall.pl on startup and on every refresh window.
+#
+# This script stays in the schedule as the hook point for any future
+# logic (e.g. log rotation snapshots, off-host upload).
+echo "[$(date -u +%FT%TZ)] AWStats hook tick (awstats container handles the refresh itself)."

--- a/docker/monit/monit.cfg
+++ b/docker/monit/monit.cfg
@@ -1,0 +1,54 @@
+# Monit configuration for the Haskala production cluster.
+#
+# - Daemon polls every 30 s.
+# - HTTP UI listens on :2812; nginx then proxies /monit/ to it with
+#   basic auth (the credentials sit in the upstream container's env;
+#   nginx forwards them via Authorization: Basic).
+# - Each `check host X` block alerts and restarts the matching docker
+#   container when its port stops responding. Restarts are issued
+#   through the docker socket mounted into this container.
+#
+# Mail alerts are off by default; set MAILSERVER, ALERT_FROM and
+# ALERT_TO env vars (and uncomment the `set mailserver`/`set alert`
+# blocks below) once a real MTA is in place.
+
+set daemon 30
+set logfile /var/log/monit/monit.log
+
+set httpd port 2812
+    allow 0.0.0.0/0
+
+# set mailserver postfix port 25
+# set alert ops@example.org
+
+check host web with address web
+    if failed port 8000 type tcp for 3 cycles then alert
+    if failed port 8000 type tcp for 5 cycles then exec "/usr/bin/env docker restart haskala-web-1"
+
+check host nginx with address nginx
+    if failed port 80 protocol http for 3 cycles then alert
+    if failed port 80 protocol http for 5 cycles then exec "/usr/bin/env docker restart haskala-nginx-1"
+
+check host db with address db
+    if failed port 5432 type tcp for 3 cycles then alert
+    if failed port 5432 type tcp for 5 cycles then exec "/usr/bin/env docker restart haskala-db-1"
+
+check host redis with address redis
+    if failed port 6379 type tcp for 3 cycles then alert
+    if failed port 6379 type tcp for 5 cycles then exec "/usr/bin/env docker restart haskala-redis-1"
+
+check host solr with address solr
+    if failed port 8983 protocol http for 3 cycles then alert
+    if failed port 8983 protocol http for 5 cycles then exec "/usr/bin/env docker restart haskala-solr-1"
+
+check host fuseki with address fuseki
+    if failed port 3030 protocol http for 3 cycles then alert
+    if failed port 3030 protocol http for 5 cycles then exec "/usr/bin/env docker restart haskala-fuseki-1"
+
+check host awstats with address awstats
+    if failed port 80 protocol http for 3 cycles then alert
+    if failed port 80 protocol http for 5 cycles then exec "/usr/bin/env docker restart haskala-awstats-1"
+
+check host postfix with address postfix
+    if failed port 25 type tcp for 3 cycles then alert
+    if failed port 25 type tcp for 5 cycles then exec "/usr/bin/env docker restart haskala-postfix-1"

--- a/haskala/settings/production.py
+++ b/haskala/settings/production.py
@@ -49,6 +49,15 @@ SECURE_REFERRER_POLICY = env(
 )
 X_FRAME_OPTIONS = env("X_FRAME_OPTIONS", default="DENY")
 
+# In production the postfix sidecar accepts plain SMTP on the docker
+# network and relays out via the institutional SMTP server (see
+# docker-compose.prod.yml). Override the base module's TLS-on-465
+# defaults that target an external SMTP directly.
+EMAIL_HOST = env("EMAIL_HOST", default="postfix")
+EMAIL_PORT = env("EMAIL_PORT", default=25, cast=int)
+EMAIL_USE_TLS = env("EMAIL_USE_TLS", default=False, cast=bool)
+EMAIL_USE_SSL = env("EMAIL_USE_SSL", default=False, cast=bool)
+
 try:
     from .local import *  # noqa: F401,F403
 except ImportError:


### PR DESCRIPTION
Second of three docker PRs. Adds production-only services in `docker-compose.prod.yml` so dev's plain `docker compose up` stays untouched.

Switch to production with:

```bash
docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env up -d
```

## What

- **monit** — watchdog, HTTP UI on :2812, docker-socket-driven restarts after 5 failed cycles.
- **awstats** — reads nginx access logs via the shared bind-mount; persistent DB at `${HASKALA_DATA_DIR}/awstats/data`.
- **cron** — alpine + cron + logrotate + postgresql-client + curl. Owns monthly Fuseki GSP dumps, AWStats hook, weekly logrotate (SIGUSR1's nginx).
- **postfix** — relays outbound mail to ${EMAIL_RELAY_HOST}; Django sends to `postfix:25`.
- **mailserver** moves behind `profiles: ["dev-only"]` so the production overlay skips it.
- **.env.example** documents every new knob.

## Test plan

- [x] `docker compose -f docker-compose.yml -f docker-compose.prod.yml config --quiet` exit 0
- [x] Effective services after merge: awstats, backups, cron, db, fuseki, monit, nginx, postfix, redis, solr, web (mailserver excluded)
- [x] `docker compose ... build cron` builds clean
- [x] manage.py test 42/42, flake8 clean

PR-C follows: nginx `/awstats/` + `/monit/` upstreams, basic auth, docs polish.