### PR TITLE
feat(docker): nginx /awstats/ + /monit/ + shared access log

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,10 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - static_data:/var/www/static:ro
+      # Access log writes here. The prod overlay shares this same
+      # bind-mount with awstats + cron; dev just lets the file
+      # accumulate locally (gitignored under data/).
+      - ${HASKALA_DATA_DIR:-./data}/awstats/logs:/var/local/log
     ports:
       # Host port 8080 to avoid clashing with any local web server
       # already bound to 80; site is then reachable at http://localhost:8080

--- a/docs/developers/setup.md
+++ b/docs/developers/setup.md
@@ -45,6 +45,35 @@ with:
 docker compose exec backups /usr/local/bin/restore.sh latest
 ```
 
+### Production stack
+
+Production layers a second compose file on top of the base. It adds
+**monit** (watchdog), **awstats** (web statistics), **cron** (monthly
+Fuseki dump + AWStats refresh + logrotate) and a **postfix** sidecar
+that relays the Django contact form through the institutional SMTP
+server. MailHog is gated behind the `dev-only` compose profile and is
+not started.
+
+```bash
+cp .env.example .env
+# Edit .env: SECRET_KEY, ALLOWED_HOSTS, CSRF_TRUSTED_ORIGINS,
+# EMAIL_RELAY_HOST/USER/PASSWORD, FUSEKI_ADMIN_PASSWORD,
+# MONIT_USERNAME/PASSWORD, HASKALA_DATA_DIR=/srv/haskala (or similar).
+
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+After the first cron tick, the proxied admin surfaces are reachable at:
+
+- `https://<host>/awstats/awstats.pl?config=haskala` — web statistics.
+- `https://<host>/monit/` — watchdog UI (basic auth via
+  `MONIT_USERNAME` / `MONIT_PASSWORD`).
+
+Monit polls each container every 30 s; if the relevant port stays
+unresponsive for five cycles it triggers `docker restart` via the
+mounted docker socket. See `docker/monit/monit.cfg` for the per-service
+rules.
+
 A superuser:
 
 ```bash

--- a/nginx.conf
+++ b/nginx.conf
@@ -48,6 +48,20 @@ http {
         keepalive      16;
     }
 
+    # AWStats consumes one combined-format access log per virtual site.
+    # In dev /var/local/log/ is not bind-mounted so nginx writes here
+    # locally (and never gets reaped); in prod the same path is shared
+    # with the awstats + cron containers.
+    log_format awstats_combined '$remote_addr - $remote_user [$time_local] '
+                                '"$request" $status $body_bytes_sent '
+                                '"$http_referer" "$http_user_agent"';
+
+    # Docker's embedded DNS resolver. With it, `proxy_pass http://$var/`
+    # form below resolves at request time instead of at config-load
+    # time, which is how dev keeps starting cleanly even though the
+    # awstats / monit hostnames only exist under the prod overlay.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
     server {
         listen      80;
         server_name _;
@@ -70,6 +84,7 @@ http {
         }
 
         location / {
+            access_log         /var/local/log/access.log awstats_combined;
             proxy_pass         http://haskala_web;
             proxy_http_version 1.1;
             proxy_set_header   Connection        "";
@@ -78,6 +93,32 @@ http {
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
             proxy_read_timeout 60s;
+        }
+
+        # AWStats web statistics. Production-only; in dev nginx returns
+        # 502 because the awstats container does not exist.
+        # Set $upstream so resolution happens at request time.
+        location /awstats/ {
+            set $awstats_upstream "awstats";
+            rewrite ^/awstats/?(.*)$ /$1 break;
+            proxy_pass         http://$awstats_upstream:80/;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        # Monit watchdog UI. Same dev/prod split as /awstats/. The
+        # upstream container ships its own basic auth via MONIT_USERNAME
+        # / MONIT_PASSWORD, so no extra auth_basic block is needed here.
+        location /monit/ {
+            set $monit_upstream "monit";
+            rewrite ^/monit/?(.*)$ /$1 break;
+            proxy_pass         http://$monit_upstream:2812/;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
Third and final docker PR. Wires the production-only awstats / monit containers into the public nginx entry, and shares the access log between nginx, awstats and cron.

Highlights:
- /awstats/ and /monit/ proxy locations using `resolver 127.0.0.11` so dev's nginx still starts when those containers don't exist (502 on visit, but no startup failure).
- New `awstats_combined` log format → `/var/local/log/access.log` (shared bind-mount under `${HASKALA_DATA_DIR}/awstats/logs`).
- docs/developers/setup.md grows a Production stack section.

## Test plan
- [x] nginx -t clean
- [x] Dev `docker compose up`: `/` and `/books/` 200; `/awstats/` and `/monit/` 502 (containers absent)
- [x] Access log persists at data/awstats/logs/access.log
- [x] manage.py test 42/42, flake8 clean