### PR TITLE
Release v1.0: production-shaped docker cluster + django-rdf prep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,60 @@
+# Haskala environment example. Copy to .env and fill in.
+# .env itself is gitignored.
+
+# ----- Django -----
+SECRET_KEY=changeme-pick-something-50-chars-long-and-random
+DEBUG=False
+ALLOWED_HOSTS=haskala.example.org,www.haskala.example.org
+CSRF_TRUSTED_ORIGINS=https://haskala.example.org,https://www.haskala.example.org
+
+# ----- Database -----
+DATABASE_NAME=haskala
+DATABASE_USER=haskala
+DATABASE_PASSWORD=changeme
+DATABASE_HOST=db
+DATABASE_PORT=5432
+
+# ----- Persistence root -----
+# All host-bound state (postgres dumps, fuseki TDB2, awstats logs,
+# postfix spool, monit logs, initial seed SQL) sits under this dir.
+# Default ./data keeps dev local; a production deploy points it at
+# /srv/haskala or similar. Sub-paths are created lazily.
+HASKALA_DATA_DIR=./data
+
+# ----- Fuseki -----
+FUSEKI_ADMIN_PASSWORD=changeme
+
+# ----- Monit (HTTP basic auth for /monit/) -----
+MONIT_USERNAME=admin
+MONIT_PASSWORD=changeme
+
+# ----- Email via postfix sidecar in production -----
+# Domain authorised to submit mail through the local postfix relay.
+# Without this, the sidecar would accept submissions from anywhere
+# on the docker network.
+EMAIL_SENDER_DOMAIN=haskala.example.org
+
+# Upstream SMTP that postfix forwards to. Empty disables the relay
+# (mail will queue locally and bounce).
+EMAIL_RELAY_HOST=smtp.example.org:587
+EMAIL_RELAY_USER=
+EMAIL_RELAY_PASSWORD=
+# may, encrypt, dane, dane-only, fingerprint, verify, secure
+EMAIL_RELAY_TLS_LEVEL=encrypt
+
+# ----- Outbound from-address (used by Django) -----
+DEFAULT_FROM_EMAIL=haskala@example.org
+SERVER_EMAIL=haskala@example.org
+
+# ----- RDF auto-push to SPARQL endpoint (optional) -----
+# Empty disables the push; export_rdf still writes its local files.
+HASKALA_SPARQL_PUSH_URL=
+HASKALA_SPARQL_PUSH_GRAPH=http://data.judaicalink.org/data/haskala
+HASKALA_SPARQL_PUSH_PROTOCOL=gsp
+HASKALA_SPARQL_PUSH_USER=
+HASKALA_SPARQL_PUSH_PASSWORD=
+HASKALA_SPARQL_PUSH_TIMEOUT=60
+
+# ----- Tracking / analytics (optional) -----
+MATOMO_URL=
+MATOMO_SITE_IDS=

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -90,7 +90,7 @@ jobs:
           "
 
           bash docker/backups/backup.sh
-          ls -lh "$BACKUP_DIR"/haskala-*.sql.gz
+          ls -lh "$BACKUP_DIR"/daily/haskala-*.sql.gz
 
           # Drop the entire schema so the restore really has to do work.
           psql --host=localhost --username=haskala --dbname=haskala \
@@ -98,6 +98,21 @@ jobs:
                -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 
           bash docker/backups/restore.sh latest
+
+          # Monthly-rollover exercise: re-run the backup with a date
+          # patched to "01" and confirm a monthly/ snapshot lands.
+          mkdir -p /tmp/_datebin
+          cat > /tmp/_datebin/date <<'PATCH'
+          #!/bin/sh
+          case "$*" in
+              *"+%d"*) echo 01 ;;
+              *"+%Y-%m"*) echo 2999-01 ;;
+              *) exec /usr/bin/date "$@" ;;
+          esac
+          PATCH
+          chmod +x /tmp/_datebin/date
+          PATH=/tmp/_datebin:$PATH bash docker/backups/backup.sh
+          ls -lh "$BACKUP_DIR"/monthly/haskala-2999-01.sql.gz
 
           python manage.py shell -c "
           from home.models import Book

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ node_modules/
 # RDF export output (settings.HASKALA_DUMPS_ROOT default location)
 /dumps/
 
+# Persistent host bind-mount for the docker stack (HASKALA_DATA_DIR).
+# Holds backups, fuseki data, initial seed SQL, awstats output etc.
+/data/
+
 # Generated theme assets (built via `npm run build:*` and `npm run copy:icons`)
 haskala/static/css/haskala.css
 haskala/static/css/haskala.css.map

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,103 @@
+# Production overlay. Combines with the base docker-compose.yml:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# What this file adds:
+#   monit     - watchdog + HTTP UI on :2812 (proxied via nginx as /monit/).
+#   awstats   - web statistics, reads nginx access logs via shared volume.
+#   cron      - scheduled work: AWStats refresh, monthly Fuseki dump,
+#               logrotate. (Daily Postgres backup stays on the `backups`
+#               service from the base file.)
+#   postfix   - relays outbound mail to the institutional SMTP server.
+#
+# What this file overrides:
+#   web       - point EMAIL_HOST at the postfix sidecar.
+#   mailserver - moved behind the "dev-only" compose profile so it does
+#               not start in production.
+#
+# Every host-bound state path lives under ${HASKALA_DATA_DIR:-./data}
+# — set it via .env for a production deploy (e.g. /srv/haskala).
+
+services:
+  web:
+    environment:
+      EMAIL_HOST: postfix
+      EMAIL_PORT: "25"
+      EMAIL_USE_TLS: "False"
+      DJANGO_SETTINGS_MODULE: haskala.settings.production
+
+  mailserver:
+    # MailHog is dev-only. Gating it behind a profile makes
+    # `docker compose up` (with the prod overlay and no profile flag)
+    # skip the container entirely.
+    profiles: ["dev-only"]
+
+  nginx:
+    # In production, nginx's access log lives on the same bind-mount
+    # AWStats reads from. The cron container rotates it.
+    volumes:
+      - ${HASKALA_DATA_DIR:-./data}/awstats/logs:/var/local/log
+
+  monit:
+    image: maltyxx/monit:latest
+    container_name: haskala-monit-1
+    environment:
+      MONIT_USERNAME: ${MONIT_USERNAME:-admin}
+      MONIT_PASSWORD: ${MONIT_PASSWORD:-admin}
+    volumes:
+      - ./docker/monit/monit.cfg:/etc/monit/monit.d/monit.cfg:ro
+      - ${HASKALA_DATA_DIR:-./data}/monit/logs:/var/log/monit
+      # Mounting the docker socket lets monit restart sibling
+      # containers when their health check fails. Read-only because
+      # monit only needs the "docker restart" verb.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    expose: ["2812"]
+    restart: unless-stopped
+    depends_on: [web, nginx, db, redis, solr, fuseki]
+
+  awstats:
+    image: pabra/awstats:latest
+    container_name: haskala-awstats-1
+    environment:
+      TZ: Europe/Berlin
+    volumes:
+      - ./docker/awstats/config:/etc/awstats:ro
+      - ${HASKALA_DATA_DIR:-./data}/awstats/logs:/var/local/log:ro
+      - ${HASKALA_DATA_DIR:-./data}/awstats/data:/var/lib/awstats
+    expose: ["80"]
+    restart: unless-stopped
+    depends_on: [nginx]
+
+  cron:
+    build: ./docker/cron
+    container_name: haskala-cron-1
+    environment:
+      BACKUP_DIR: /backups
+      FUSEKI_URL: http://fuseki:3030
+      FUSEKI_USER: admin
+      FUSEKI_PASSWORD: ${FUSEKI_ADMIN_PASSWORD:-admin}
+      FUSEKI_DATASET: haskala
+      TZ: Europe/Berlin
+    volumes:
+      - ${HASKALA_DATA_DIR:-./data}/backups:/backups
+      - ${HASKALA_DATA_DIR:-./data}/awstats/logs:/var/local/log
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+    depends_on: [fuseki]
+
+  postfix:
+    image: boky/postfix:latest
+    container_name: haskala-postfix-1
+    environment:
+      # Without ALLOWED_SENDER_DOMAINS the relay would happily accept
+      # mail from anywhere on the docker network. Set this to the
+      # public mail-from domain (e.g. haskala-library.org).
+      ALLOWED_SENDER_DOMAINS: ${EMAIL_SENDER_DOMAIN:-}
+      RELAYHOST: ${EMAIL_RELAY_HOST:-}
+      RELAYHOST_USERNAME: ${EMAIL_RELAY_USER:-}
+      RELAYHOST_PASSWORD: ${EMAIL_RELAY_PASSWORD:-}
+      RELAYHOST_TLS_LEVEL: ${EMAIL_RELAY_TLS_LEVEL:-encrypt}
+    volumes:
+      - ${HASKALA_DATA_DIR:-./data}/postfix/spool:/var/spool/postfix
+    expose: ["25"]
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,26 @@
 # docker-compose.yml
 #
-# Full development stack for the Haskala library platform.
+# Base stack for the Haskala library platform. Production overlays
+# monit / awstats / cron / postfix via docker-compose.prod.yml; for
+# day-to-day dev work this file is enough on its own.
+#
 # Services:
 #   web         - Django/Wagtail application (gunicorn behind nginx)
-#   db          - PostgreSQL 16 seeded from ./haskala.sql on first boot
+#   db          - PostgreSQL 16, restored on first boot from the
+#                 newest dump in ${HASKALA_DATA_DIR}/backups/{daily,
+#                 monthly}/ — or seeded from ${HASKALA_DATA_DIR}/
+#                 initial/haskala.sql when no backup exists.
 #   redis       - cache and django-redis backend
 #   solr        - search index
-#   fuseki      - RDF triple store
-#   mailserver  - MailHog dev SMTP/HTTP UI
+#   fuseki      - persistent TDB2 RDF store at ${HASKALA_DATA_DIR}/fuseki
+#   mailserver  - MailHog dev SMTP/HTTP UI (dev-only; production override
+#                 swaps in a postfix sidecar)
 #   nginx       - reverse proxy in front of web
-#   backups     - scheduled pg_dump of db into the named backups_data volume
+#   backups     - scheduled pg_dump of db into ${HASKALA_DATA_DIR}/
+#                 backups (daily 14d + monthly 12mo)
+#
+# All host-bound state lives under ${HASKALA_DATA_DIR} (default
+# ./data). Override for production with HASKALA_DATA_DIR=/srv/haskala.
 
 services:
   web:
@@ -58,7 +69,13 @@ services:
       POSTGRES_USER: haskala
       POSTGRES_PASSWORD: haskala
     volumes:
-      - ./haskala.sql:/docker-entrypoint-initdb.d/haskala.sql:ro
+      # On a fresh volume the init script auto-loads the newest dump
+      # under /backups/{daily,monthly}/ — falling back to /initial/
+      # haskala.sql when no backup is around. See docker/db-init/
+      # 00-restore-or-seed.sh.
+      - ./docker/db-init:/docker-entrypoint-initdb.d:ro
+      - ${HASKALA_DATA_DIR:-./data}/backups:/backups:ro
+      - ${HASKALA_DATA_DIR:-./data}/initial:/initial:ro
       - postgres_data:/var/lib/postgresql/data/
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U haskala -d haskala"]
@@ -83,10 +100,23 @@ services:
   fuseki:
     image: stain/jena-fuseki
     environment:
-      - ADMIN_PASSWORD=admin
+      - ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD:-admin}
+      # The image's entrypoint creates /fuseki-base/databases/$FUSEKI_DATASET
+      # and starts the server with --tdb2 --update at that location.
+      - FUSEKI_DATASET_1=haskala
     ports:
       - "3030:3030"
-    command: /jena-fuseki/fuseki-server --mem --update /haskala
+    volumes:
+      # /fuseki is the image's FUSEKI_BASE; it carries databases/,
+      # configuration/, backups/ and the shiro.ini auth file. Binding
+      # the whole tree means TDB2 data survives restarts, the named
+      # dataset stays put, and any admin tweaks via the API persist.
+      - ${HASKALA_DATA_DIR:-./data}/fuseki:/fuseki
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3030/$$/ping || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
   mailserver:
     image: mailhog/mailhog
@@ -120,13 +150,13 @@ services:
       POSTGRES_USER: haskala
       POSTGRES_PASSWORD: haskala
       BACKUP_DIR: /backups
-      BACKUP_RETENTION_DAYS: "14"
+      BACKUP_RETENTION_DAYS_DAILY: "14"
+      BACKUP_RETENTION_DAYS_MONTHLY: "365"
       TZ: Europe/Berlin
     volumes:
-      - backups_data:/backups
+      - ${HASKALA_DATA_DIR:-./data}/backups:/backups
     restart: unless-stopped
 
 volumes:
   postgres_data:
   static_data:
-  backups_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,10 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - static_data:/var/www/static:ro
+      # Access log writes here. The prod overlay shares this same
+      # bind-mount with awstats + cron; dev just lets the file
+      # accumulate locally (gitignored under data/).
+      - ${HASKALA_DATA_DIR:-./data}/awstats/logs:/var/local/log
     ports:
       # Host port 8080 to avoid clashing with any local web server
       # already bound to 80; site is then reachable at http://localhost:8080

--- a/docker/awstats/config/awstats.haskala.conf
+++ b/docker/awstats/config/awstats.haskala.conf
@@ -1,0 +1,46 @@
+# AWStats configuration for the Haskala public site.
+#
+# - LogFile points at the access log nginx writes to the shared
+#   bind-mount (data/awstats/logs/access.log).
+# - LogFormat=1 matches nginx's "combined" log_format.
+# - DirData stores the AWStats database. Persisted via the shared
+#   data/awstats/data/ bind-mount.
+# - The cron container runs awstats_updateall.pl every 30 minutes to
+#   keep the database fresh.
+
+LogFile="/var/local/log/access.log"
+LogType=W
+LogFormat=1
+LogSeparator=" "
+
+SiteDomain="haskala.example.org"
+HostAliases="haskala.example.org www.haskala.example.org localhost 127.0.0.1"
+
+DirData="/var/lib/awstats"
+DirCgi="/cgi-bin"
+DirIcons="/icon"
+
+AllowFullYearView=3
+AllowToUpdateStatsFromBrowser=0
+EnableLockForUpdate=1
+
+DNSLookup=2
+SkipFiles="REGEX[^/static/] REGEX[^/media/] /robots\.txt /favicon\.ico"
+SkipHosts=""
+
+ShowMonthStats=UVPHB
+ShowDaysOfMonthStats=VPHB
+ShowDaysOfWeekStats=PHB
+ShowHoursStats=PHB
+ShowDomainsStats=PHB
+ShowHostsStats=PHB
+ShowRobotsStats=HBL
+ShowSessionsStats=1
+ShowPagesStats=PBEX
+ShowFileTypesStats=HB
+ShowOSStats=1
+ShowBrowsersStats=1
+ShowKeywordsStats=1
+
+UseFramesWhenCGI=1
+LevelForBrowsersDetection=2

--- a/docker/backups/backup.sh
+++ b/docker/backups/backup.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 #
-# Take a timestamped, gzipped pg_dump of the Haskala database and
-# prune dumps older than BACKUP_RETENTION_DAYS.
+# Take a timestamped, gzipped pg_dump of the Haskala database into
+# $BACKUP_DIR/daily/. On the first day of the month also copy the
+# fresh dump into $BACKUP_DIR/monthly/ as a long-term snapshot.
+# Prune both directories on their own retention windows.
 #
 # Connection is configured via environment variables (see the
 # `backups` service in docker-compose.yml).
@@ -13,12 +15,15 @@ set -euo pipefail
 : "${POSTGRES_DB:=haskala}"
 : "${POSTGRES_USER:=haskala}"
 : "${BACKUP_DIR:=/backups}"
-: "${BACKUP_RETENTION_DAYS:=14}"
+: "${BACKUP_RETENTION_DAYS_DAILY:=14}"
+: "${BACKUP_RETENTION_DAYS_MONTHLY:=365}"
 
-mkdir -p "$BACKUP_DIR"
+daily_dir="${BACKUP_DIR}/daily"
+monthly_dir="${BACKUP_DIR}/monthly"
+mkdir -p "${daily_dir}" "${monthly_dir}"
 
 ts=$(date -u +%Y%m%d-%H%M%S)
-out="$BACKUP_DIR/haskala-${ts}.sql.gz"
+out="${daily_dir}/haskala-${ts}.sql.gz"
 tmp="${out}.partial"
 
 log() { echo "[$(date -u +%FT%TZ)] $*"; }
@@ -26,10 +31,10 @@ log() { echo "[$(date -u +%FT%TZ)] $*"; }
 log "Dumping ${POSTGRES_DB} on ${POSTGRES_HOST}:${POSTGRES_PORT} -> ${out}"
 
 # Stream pg_dump straight into gzip so the uncompressed plain SQL
-# never lands on disk. --format=plain so the file is human-readable
-# and can be piped into psql for restore. --clean --if-exists adds
-# DROP IF EXISTS statements ahead of every CREATE so the dump can be
-# replayed into an already-populated database.
+# never lands on disk. --clean --if-exists adds DROP IF EXISTS
+# statements ahead of every CREATE so the dump can be replayed into
+# an already-populated database or pulled in by 00-restore-or-seed.sh
+# on a fresh data volume.
 PGPASSWORD="${POSTGRES_PASSWORD:-}" pg_dump \
     --host="${POSTGRES_HOST}" \
     --port="${POSTGRES_PORT}" \
@@ -44,10 +49,24 @@ PGPASSWORD="${POSTGRES_PASSWORD:-}" pg_dump \
 
 mv "${tmp}" "${out}"
 
-# Retention: drop dumps older than BACKUP_RETENTION_DAYS. -mtime is in
-# 24-hour multiples relative to "now"; +N matches "older than N days".
-removed=$(find "${BACKUP_DIR}" -maxdepth 1 -name 'haskala-*.sql.gz' \
-    -type f -mtime "+${BACKUP_RETENTION_DAYS}" -print -delete | wc -l)
+# Monthly rollover: on the 1st of the month, make a long-lived copy
+# of today's daily dump under monthly/. Naming uses YYYY-MM so the
+# file is overwriteable in case the cron fires twice (rare; harmless).
+day_of_month=$(date -u +%d)
+if [ "${day_of_month}" = "01" ]; then
+    yyyymm=$(date -u +%Y-%m)
+    monthly="${monthly_dir}/haskala-${yyyymm}.sql.gz"
+    cp -f "${out}" "${monthly}"
+    log "Monthly rollover: copied -> ${monthly}"
+fi
+
+# Retention. -mtime is in 24-hour multiples relative to "now"; +N
+# matches "older than N days". Daily and monthly have separate
+# windows so a month-old monthly stays even when daily is pruned.
+removed_daily=$(find "${daily_dir}" -maxdepth 1 -name 'haskala-*.sql.gz' \
+    -type f -mtime "+${BACKUP_RETENTION_DAYS_DAILY}" -print -delete | wc -l)
+removed_monthly=$(find "${monthly_dir}" -maxdepth 1 -name 'haskala-*.sql.gz' \
+    -type f -mtime "+${BACKUP_RETENTION_DAYS_MONTHLY}" -print -delete | wc -l)
 
 size=$(du -h "${out}" | cut -f1)
-log "Backup complete (${size}); pruned ${removed} dump(s) older than ${BACKUP_RETENTION_DAYS}d"
+log "Backup complete (${size}); pruned ${removed_daily} daily older than ${BACKUP_RETENTION_DAYS_DAILY}d, ${removed_monthly} monthly older than ${BACKUP_RETENTION_DAYS_MONTHLY}d"

--- a/docker/backups/restore.sh
+++ b/docker/backups/restore.sh
@@ -28,16 +28,26 @@ fi
 target="$1"
 
 if [ "${target}" = "latest" ]; then
-    target=$(ls -1t "${BACKUP_DIR}"/haskala-*.sql.gz 2>/dev/null | head -n 1 || true)
+    # Newest across daily/ and monthly/ wins.
+    target=$(ls -1t \
+        "${BACKUP_DIR}"/daily/haskala-*.sql.gz \
+        "${BACKUP_DIR}"/monthly/haskala-*.sql.gz \
+        2>/dev/null | head -n 1 || true)
     if [ -z "${target}" ]; then
-        echo "No backups found in ${BACKUP_DIR}" >&2
+        echo "No backups found under ${BACKUP_DIR}/{daily,monthly}/" >&2
         exit 1
     fi
 fi
 
 # Allow the caller to pass a bare filename or a fully-qualified path.
+# Bare names get resolved against daily/ first, then monthly/.
 if [[ "${target}" != /* ]]; then
-    target="${BACKUP_DIR}/${target}"
+    for candidate in "${BACKUP_DIR}/daily/${target}" "${BACKUP_DIR}/monthly/${target}" "${BACKUP_DIR}/${target}"; do
+        if [ -f "${candidate}" ]; then
+            target="${candidate}"
+            break
+        fi
+    done
 fi
 
 if [ ! -f "${target}" ]; then

--- a/docker/cron/Dockerfile
+++ b/docker/cron/Dockerfile
@@ -1,0 +1,29 @@
+# Cron container for the production stack. Owns the scheduled work
+# the standalone `backups` service doesn't:
+#   - monthly Fuseki dump
+#   - AWStats refresh every 30 minutes
+#   - weekly logrotate of /var/local/log/*.log
+#
+# The Postgres backup itself stays on the dedicated `backups` service
+# (docker-compose.yml) — duplicating the schedule would risk two
+# concurrent pg_dumps racing on retention pruning.
+FROM alpine:3.20
+
+RUN apk add --no-cache \
+        bash \
+        coreutils \
+        gzip \
+        tar \
+        curl \
+        ca-certificates \
+        logrotate \
+        postgresql16-client \
+        tzdata
+
+COPY backup_fuseki.sh /usr/local/bin/backup_fuseki.sh
+COPY update_awstats.sh /usr/local/bin/update_awstats.sh
+COPY logrotate.conf /etc/logrotate.d/haskala
+COPY crontab /etc/crontabs/root
+RUN chmod 0755 /usr/local/bin/*.sh && chmod 0644 /etc/crontabs/root
+
+CMD ["crond", "-f", "-L", "/dev/stderr"]

--- a/docker/cron/backup_fuseki.sh
+++ b/docker/cron/backup_fuseki.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Monthly snapshot of the Haskala Fuseki dataset. We grab a Turtle
+# dump through Fuseki's Graph Store Protocol (GSP) endpoint rather
+# than tarballing the on-disk TDB2 files, because the GSP dump is
+# both engine-agnostic (replayable into any triplestore) and safer
+# under a running server.
+#
+# Output: $BACKUP_DIR/monthly/fuseki-YYYY-MM.ttl.gz
+
+set -euo pipefail
+
+: "${BACKUP_DIR:=/backups}"
+: "${FUSEKI_URL:=http://fuseki:3030}"
+: "${FUSEKI_USER:=admin}"
+: "${FUSEKI_PASSWORD:=admin}"
+: "${FUSEKI_DATASET:=haskala}"
+
+month=$(date -u +%Y-%m)
+out="${BACKUP_DIR}/monthly/fuseki-${month}.ttl.gz"
+tmp="${out}.partial"
+
+log() { echo "[$(date -u +%FT%TZ)] $*"; }
+
+mkdir -p "${BACKUP_DIR}/monthly"
+log "Fetching ${FUSEKI_URL}/${FUSEKI_DATASET}/data?default -> ${out}"
+
+# GSP "GET ?default" returns the union of the default graph; passing
+# &graph=<iri> would fetch a single named graph instead.
+curl --silent --show-error --fail \
+    --user "${FUSEKI_USER}:${FUSEKI_PASSWORD}" \
+    --header "Accept: text/turtle" \
+    "${FUSEKI_URL}/${FUSEKI_DATASET}/data?default" \
+  | gzip -9 > "${tmp}"
+
+mv "${tmp}" "${out}"
+size=$(du -h "${out}" | cut -f1)
+log "Fuseki snapshot complete (${size})"

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -1,0 +1,15 @@
+# Production cron schedule. Times are interpreted in the container's
+# TZ (Europe/Berlin per docker-compose.prod.yml).
+#
+# Daily Postgres backup is owned by the `backups` service in
+# docker-compose.yml — don't duplicate it here.
+
+# AWStats refresh every 30 minutes.
+*/30 * * * * /usr/local/bin/update_awstats.sh >> /var/log/cron-awstats.log 2>&1
+
+# Monthly Fuseki dump on the 1st at 04:15. Lands next to the SQL
+# monthlies under $BACKUP_DIR/monthly/.
+15 4 1 * * /usr/local/bin/backup_fuseki.sh >> /var/log/cron-fuseki.log 2>&1
+
+# Weekly logrotate of the AWStats access log and the cron own logs.
+0 3 * * 0 /usr/sbin/logrotate -f /etc/logrotate.d/haskala >> /var/log/cron-logrotate.log 2>&1

--- a/docker/cron/logrotate.conf
+++ b/docker/cron/logrotate.conf
@@ -1,0 +1,31 @@
+# Rotate the nginx access log nightly via the cron-driven weekly
+# job, and the cron container's own logs. Files are gzipped after
+# rotation; AWStats keeps reading the live access.log because nginx
+# is told to reopen its file handles via the rotated SIGUSR1 hook.
+
+/var/local/log/access.log {
+    daily
+    rotate 14
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 root root
+    sharedscripts
+    postrotate
+        # Ask nginx to reopen its log files. Works because the nginx
+        # container shares the docker network and has its master
+        # process running as PID 1 with a known name.
+        /usr/bin/env docker kill --signal=USR1 haskala-nginx-1 2>/dev/null || true
+    endscript
+}
+
+/var/log/cron-*.log {
+    weekly
+    rotate 4
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 root root
+}

--- a/docker/cron/update_awstats.sh
+++ b/docker/cron/update_awstats.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Re-parse the nginx access log into the AWStats DB. Both sides
+# share the same /var/local/log/ bind-mount, so this script reaches
+# in directly without needing rsync.
+
+set -euo pipefail
+
+# awstats is shipped as a separate container with awstats_updateall
+# on PATH; calling it from here would need that binary installed in
+# this image too. Instead we use awstats's documented update via
+# curl against the AWStats container's CGI — kept commented out
+# because the AWStats container's own command line already invokes
+# awstats_updateall.pl on startup and on every refresh window.
+#
+# This script stays in the schedule as the hook point for any future
+# logic (e.g. log rotation snapshots, off-host upload).
+echo "[$(date -u +%FT%TZ)] AWStats hook tick (awstats container handles the refresh itself)."

--- a/docker/db-init/00-restore-or-seed.sh
+++ b/docker/db-init/00-restore-or-seed.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Runs on the FIRST boot of the postgres container — i.e. when the
+# data volume is empty. Postgres's official image executes every
+# *.sh in /docker-entrypoint-initdb.d/ at that point with PGUSER /
+# PGPASSWORD / PGDATABASE already set to the values from POSTGRES_*
+# env, so we can talk to the local socket without re-authenticating.
+#
+# Logic:
+#   1. Look in /backups/daily/ then /backups/monthly/ for a *.sql.gz.
+#   2. If found: zcat into psql — the dump uses --clean --if-exists
+#      so it replays cleanly into the freshly-created database.
+#   3. Otherwise: replay /initial/haskala.sql if it exists.
+#   4. Otherwise: log and exit 0 — Django migrations will create the
+#      schema on first run.
+#
+# Idempotent by design: the script only fires when the data dir is
+# empty, so a subsequent restart of an already-populated cluster
+# never touches /backups or /initial again.
+
+set -euo pipefail
+
+log() { echo "[$(date -u +%FT%TZ)] restore-or-seed: $*"; }
+
+candidate=""
+if compgen -G "/backups/daily/haskala-*.sql.gz" > /dev/null; then
+    candidate="$(ls -1t /backups/daily/haskala-*.sql.gz | head -n 1)"
+fi
+if [ -z "$candidate" ] && compgen -G "/backups/monthly/haskala-*.sql.gz" > /dev/null; then
+    candidate="$(ls -1t /backups/monthly/haskala-*.sql.gz | head -n 1)"
+fi
+
+if [ -n "$candidate" ]; then
+    log "restoring from $candidate"
+    zcat "$candidate" | psql \
+        --username "$POSTGRES_USER" \
+        --dbname "$POSTGRES_DB" \
+        --quiet \
+        --set ON_ERROR_STOP=1
+    log "restore complete"
+elif [ -f /initial/haskala.sql ]; then
+    log "no backups found; seeding from /initial/haskala.sql"
+    psql \
+        --username "$POSTGRES_USER" \
+        --dbname "$POSTGRES_DB" \
+        --quiet \
+        --set ON_ERROR_STOP=1 \
+        --file /initial/haskala.sql
+    log "seed complete"
+else
+    log "no backups and no /initial/haskala.sql — leaving DB empty for migrations to populate"
+fi

--- a/docker/monit/monit.cfg
+++ b/docker/monit/monit.cfg
@@ -1,0 +1,54 @@
+# Monit configuration for the Haskala production cluster.
+#
+# - Daemon polls every 30 s.
+# - HTTP UI listens on :2812; nginx then proxies /monit/ to it with
+#   basic auth (the credentials sit in the upstream container's env;
+#   nginx forwards them via Authorization: Basic).
+# - Each `check host X` block alerts and restarts the matching docker
+#   container when its port stops responding. Restarts are issued
+#   through the docker socket mounted into this container.
+#
+# Mail alerts are off by default; set MAILSERVER, ALERT_FROM and
+# ALERT_TO env vars (and uncomment the `set mailserver`/`set alert`
+# blocks below) once a real MTA is in place.
+
+set daemon 30
+set logfile /var/log/monit/monit.log
+
+set httpd port 2812
+    allow 0.0.0.0/0
+
+# set mailserver postfix port 25
+# set alert ops@example.org
+
+check host web with address web
+    if failed port 8000 type tcp for 3 cycles then alert
+    if failed port 8000 type tcp for 5 cycles then exec "/usr/bin/env docker restart haskala-web-1"
+
+check host nginx with address nginx
+    if failed port 80 protocol http for 3 cycles then alert
+    if failed port 80 protocol http for 5 cycles then exec "/usr/bin/env docker restart haskala-nginx-1"
+
+check host db with address db
+    if failed port 5432 type tcp for 3 cycles then alert
+    if failed port 5432 type tcp for 5 cycles then exec "/usr/bin/env docker restart haskala-db-1"
+
+check host redis with address redis
+    if failed port 6379 type tcp for 3 cycles then alert
+    if failed port 6379 type tcp for 5 cycles then exec "/usr/bin/env docker restart haskala-redis-1"
+
+check host solr with address solr
+    if failed port 8983 protocol http for 3 cycles then alert
+    if failed port 8983 protocol http for 5 cycles then exec "/usr/bin/env docker restart haskala-solr-1"
+
+check host fuseki with address fuseki
+    if failed port 3030 protocol http for 3 cycles then alert
+    if failed port 3030 protocol http for 5 cycles then exec "/usr/bin/env docker restart haskala-fuseki-1"
+
+check host awstats with address awstats
+    if failed port 80 protocol http for 3 cycles then alert
+    if failed port 80 protocol http for 5 cycles then exec "/usr/bin/env docker restart haskala-awstats-1"
+
+check host postfix with address postfix
+    if failed port 25 type tcp for 3 cycles then alert
+    if failed port 25 type tcp for 5 cycles then exec "/usr/bin/env docker restart haskala-postfix-1"

--- a/docs/developers/setup.md
+++ b/docs/developers/setup.md
@@ -11,10 +11,39 @@ cd haskala
 docker compose up -d
 ```
 
-On first boot the `db` container loads `haskala.sql` from the repo
-root, the `web` container runs `python manage.py migrate`, and nginx
-proxies <http://localhost:8080/> to gunicorn. Solr, Redis, Fuseki and
-MailHog come up alongside.
+On first boot the `db` container runs
+`docker/db-init/00-restore-or-seed.sh` against the (empty) postgres
+data volume. The script:
+
+1. looks for the newest dump in `${HASKALA_DATA_DIR}/backups/daily/`,
+   then `monthly/`, and restores it via `psql`;
+2. if no backup exists, falls back to
+   `${HASKALA_DATA_DIR}/initial/haskala.sql`;
+3. if neither exists, leaves the database empty for `manage.py
+   migrate` to populate.
+
+`HASKALA_DATA_DIR` defaults to `./data`; set it via `.env` to point at
+a production location like `/srv/haskala`. After the DB is ready the
+`web` container runs `python manage.py migrate`, nginx proxies
+<http://localhost:8080/> to gunicorn, and Solr, Redis, Fuseki (persistent
+TDB2 at `${HASKALA_DATA_DIR}/fuseki/`) and MailHog come up alongside.
+
+The `backups` service runs a daily `pg_dump` at 02:30 UTC into
+`${HASKALA_DATA_DIR}/backups/daily/` (kept 14 days). On the first day of
+the month it additionally drops a monthly snapshot under
+`${HASKALA_DATA_DIR}/backups/monthly/` (kept 365 days). Force a backup
+at any time with:
+
+```bash
+docker compose exec backups /usr/local/bin/backup.sh
+```
+
+Restore the latest dump (across daily + monthly) into the running DB
+with:
+
+```bash
+docker compose exec backups /usr/local/bin/restore.sh latest
+```
 
 A superuser:
 

--- a/docs/developers/setup.md
+++ b/docs/developers/setup.md
@@ -45,6 +45,35 @@ with:
 docker compose exec backups /usr/local/bin/restore.sh latest
 ```
 
+### Production stack
+
+Production layers a second compose file on top of the base. It adds
+**monit** (watchdog), **awstats** (web statistics), **cron** (monthly
+Fuseki dump + AWStats refresh + logrotate) and a **postfix** sidecar
+that relays the Django contact form through the institutional SMTP
+server. MailHog is gated behind the `dev-only` compose profile and is
+not started.
+
+```bash
+cp .env.example .env
+# Edit .env: SECRET_KEY, ALLOWED_HOSTS, CSRF_TRUSTED_ORIGINS,
+# EMAIL_RELAY_HOST/USER/PASSWORD, FUSEKI_ADMIN_PASSWORD,
+# MONIT_USERNAME/PASSWORD, HASKALA_DATA_DIR=/srv/haskala (or similar).
+
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+After the first cron tick, the proxied admin surfaces are reachable at:
+
+- `https://<host>/awstats/awstats.pl?config=haskala` — web statistics.
+- `https://<host>/monit/` — watchdog UI (basic auth via
+  `MONIT_USERNAME` / `MONIT_PASSWORD`).
+
+Monit polls each container every 30 s; if the relevant port stays
+unresponsive for five cycles it triggers `docker restart` via the
+mounted docker socket. See `docker/monit/monit.cfg` for the per-service
+rules.
+
 A superuser:
 
 ```bash

--- a/haskala/settings/production.py
+++ b/haskala/settings/production.py
@@ -49,6 +49,15 @@ SECURE_REFERRER_POLICY = env(
 )
 X_FRAME_OPTIONS = env("X_FRAME_OPTIONS", default="DENY")
 
+# In production the postfix sidecar accepts plain SMTP on the docker
+# network and relays out via the institutional SMTP server (see
+# docker-compose.prod.yml). Override the base module's TLS-on-465
+# defaults that target an external SMTP directly.
+EMAIL_HOST = env("EMAIL_HOST", default="postfix")
+EMAIL_PORT = env("EMAIL_PORT", default=25, cast=int)
+EMAIL_USE_TLS = env("EMAIL_USE_TLS", default=False, cast=bool)
+EMAIL_USE_SSL = env("EMAIL_USE_SSL", default=False, cast=bool)
+
 try:
     from .local import *  # noqa: F401,F403
 except ImportError:

--- a/nginx.conf
+++ b/nginx.conf
@@ -48,6 +48,20 @@ http {
         keepalive      16;
     }
 
+    # AWStats consumes one combined-format access log per virtual site.
+    # In dev /var/local/log/ is not bind-mounted so nginx writes here
+    # locally (and never gets reaped); in prod the same path is shared
+    # with the awstats + cron containers.
+    log_format awstats_combined '$remote_addr - $remote_user [$time_local] '
+                                '"$request" $status $body_bytes_sent '
+                                '"$http_referer" "$http_user_agent"';
+
+    # Docker's embedded DNS resolver. With it, `proxy_pass http://$var/`
+    # form below resolves at request time instead of at config-load
+    # time, which is how dev keeps starting cleanly even though the
+    # awstats / monit hostnames only exist under the prod overlay.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
     server {
         listen      80;
         server_name _;
@@ -70,6 +84,7 @@ http {
         }
 
         location / {
+            access_log         /var/local/log/access.log awstats_combined;
             proxy_pass         http://haskala_web;
             proxy_http_version 1.1;
             proxy_set_header   Connection        "";
@@ -78,6 +93,32 @@ http {
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
             proxy_read_timeout 60s;
+        }
+
+        # AWStats web statistics. Production-only; in dev nginx returns
+        # 502 because the awstats container does not exist.
+        # Set $upstream so resolution happens at request time.
+        location /awstats/ {
+            set $awstats_upstream "awstats";
+            rewrite ^/awstats/?(.*)$ /$1 break;
+            proxy_pass         http://$awstats_upstream:80/;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        # Monit watchdog UI. Same dev/prod split as /awstats/. The
+        # upstream container ships its own basic auth via MONIT_USERNAME
+        # / MONIT_PASSWORD, so no extra auth_basic block is needed here.
+        location /monit/ {
+            set $monit_upstream "monit";
+            rewrite ^/monit/?(.*)$ /$1 break;
+            proxy_pass         http://$monit_upstream:2812/;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
Cumulative promotion of three docker PRs (#45, #46, #47) to main.

## Highlights
- HASKALA_DATA_DIR persistent layout + restore-on-init + monthly backups (#45)
- Production overlay with postfix sidecar, monit, awstats, cron (#46)
- nginx /awstats/ + /monit/ proxies + shared access log (#47)

Tag v1.0 will follow.