### PR TITLE
feat(rdf): route SPARQL Update push through djangordf's FusekiBackend

### DIFF
--- a/haskala/settings/base.py
+++ b/haskala/settings/base.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "django_filters",
     "drf_spectacular",
+    "djangordf",
 ]
 
 MIDDLEWARE = [
@@ -389,6 +390,47 @@ HASKALA_SPARQL_PUSH_PROTOCOL = env("HASKALA_SPARQL_PUSH_PROTOCOL", default="gsp"
 HASKALA_SPARQL_PUSH_USER = env("HASKALA_SPARQL_PUSH_USER", default="")
 HASKALA_SPARQL_PUSH_PASSWORD = env("HASKALA_SPARQL_PUSH_PASSWORD", default="")
 HASKALA_SPARQL_PUSH_TIMEOUT = env("HASKALA_SPARQL_PUSH_TIMEOUT", default=60, cast=int)
+
+# djangordf is the JudaicaLink-internal Django/RDF bridge. We use it
+# from haskala_rdf.push() to talk SPARQL Update to Fuseki; the
+# build_data_graph() pipeline keeps producing the raw rdflib graph
+# (it encodes domain-specific ontology mappings djangordf doesn't
+# know about) and the push then routes through djangordf's
+# FusekiBackend so the same library handles writes everywhere in the
+# JudaicaLink ecosystem.
+#
+# When HASKALA_SPARQL_PUSH_URL is empty djangordf falls back to its
+# bundled InMemoryBackend (no network traffic) and the push() helper
+# becomes a no-op — convenient for running the Django test suite or
+# the management commands without a triple store at hand.
+if HASKALA_SPARQL_PUSH_URL:
+    # The FusekiBackend expects the dataset root, not the GSP/update
+    # endpoint. Strip a trailing /data or /update so the user can paste
+    # in either flavour as HASKALA_SPARQL_PUSH_URL.
+    _dataset_root = HASKALA_SPARQL_PUSH_URL
+    for _suffix in ("/data", "/update", "/query"):
+        if _dataset_root.endswith(_suffix):
+            _dataset_root = _dataset_root[: -len(_suffix)]
+            break
+    DJANGORDF_BACKEND = {
+        "class": "djangordf.backends.fuseki.FusekiBackend",
+        "endpoint": _dataset_root,
+    }
+    if HASKALA_SPARQL_PUSH_USER:
+        DJANGORDF_BACKEND["user"] = HASKALA_SPARQL_PUSH_USER
+        DJANGORDF_BACKEND["password"] = HASKALA_SPARQL_PUSH_PASSWORD
+else:
+    DJANGORDF_BACKEND = {
+        "class": "djangordf.backends.memory.InMemoryBackend",
+    }
+DJANGORDF_DEFAULT_NAMESPACE = "http://data.judaicalink.org/data/haskala/"
+DJANGORDF_DEFAULT_GRAPH = HASKALA_SPARQL_PUSH_GRAPH
+DJANGORDF_NAMESPACES = {
+    "hs": "http://data.judaicalink.org/ontology/haskala#",
+    "hsk": "http://data.judaicalink.org/data/haskala/",
+    "jl": "http://data.judaicalink.org/ontology/",
+    "gndo": "http://d-nb.info/standards/elementset/gnd#",
+}
 
 # Mail
 EMAIL_BACKEND = env("EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend")

--- a/haskala_rdf/push.py
+++ b/haskala_rdf/push.py
@@ -5,10 +5,12 @@ Two protocols are supported:
 
 - **Graph Store Protocol (GSP)** — the default. Uploads the serialized
   Turtle as the entire content of one named graph via HTTP PUT. Fuseki
-  exposes this at ``/<dataset>/data``.
-- **SPARQL 1.1 Update** — falls back to inline ``DROP SILENT GRAPH …;
-  INSERT DATA { GRAPH … { … } }`` over HTTP POST when ``protocol="update"``.
-  Fuseki's update endpoint is ``/<dataset>/update``.
+  exposes this at ``/<dataset>/data``. djangordf's FusekiBackend does
+  not cover GSP itself, so this path stays on plain ``requests.put``.
+- **SPARQL 1.1 Update** — routes through
+  :class:`djangordf.backends.fuseki.FusekiBackend`. We send one
+  ``DROP SILENT GRAPH …; INSERT DATA { GRAPH … { … } }`` transaction
+  that the backend posts to ``/<dataset>/update``.
 
 Both paths replace the named graph wholesale; calling the push twice
 produces the same end state.
@@ -30,19 +32,19 @@ class PushTarget:
     timeout_seconds: int = 60
 
 
-def push_graph(graph: Graph, target: PushTarget) -> requests.Response:
+def push_graph(graph: Graph, target: PushTarget):
     """
-    Push *graph* to *target.url*. Returns the underlying HTTP Response.
+    Push *graph* to *target.url*. Returns either a ``requests.Response``
+    (gsp path) or ``None`` (update path — djangordf's backend has no
+    response object to surface).
 
     Raises ``requests.HTTPError`` on a 4xx/5xx response so callers can
-    fail loudly. Otherwise the caller gets the response object back
-    and can inspect status / headers.
+    fail loudly.
     """
-    body = graph.serialize(format="turtle")
-    if isinstance(body, str):
-        body = body.encode("utf-8")
-
     if target.protocol == "gsp":
+        body = graph.serialize(format="turtle")
+        if isinstance(body, str):
+            body = body.encode("utf-8")
         response = requests.put(
             target.url,
             params={"graph": target.graph_iri},
@@ -51,34 +53,45 @@ def push_graph(graph: Graph, target: PushTarget) -> requests.Response:
             auth=target.auth,
             timeout=target.timeout_seconds,
         )
-    elif target.protocol == "update":
-        # Strip the @prefix and @base lines out of the Turtle and wrap
-        # the rest in a SPARQL UPDATE block. rdflib's `application/
-        # sparql-update` is easier to construct from N-Triples than
-        # from Turtle because UPDATE statements use SPARQL syntax for
-        # prefixes — keep things simple and ship the triples raw.
+        response.raise_for_status()
+        return response
+
+    if target.protocol == "update":
+        # Route through djangordf's FusekiBackend so the same library
+        # handles SPARQL writes everywhere in the JudaicaLink stack.
+        # We pass the dataset root (stripping a /update / /data tail
+        # if the caller pre-attached one).
+        from djangordf.backends.fuseki import FusekiBackend
+
+        endpoint = target.url
+        for suffix in ("/update", "/data", "/query"):
+            if endpoint.endswith(suffix):
+                endpoint = endpoint[: -len(suffix)]
+                break
+        backend_kwargs: dict = {"endpoint": endpoint}
+        if target.auth is not None:
+            backend_kwargs["user"], backend_kwargs["password"] = target.auth
+        backend = FusekiBackend(**backend_kwargs)
+
+        # Serialize the graph to N-Triples and wrap in a single SPARQL
+        # transaction. djangordf's backend.update() POSTs the body to
+        # /<dataset>/update with the right content-type.
         nt = graph.serialize(format="nt")
-        if isinstance(nt, str):
-            nt = nt.encode("utf-8")
-        update = (
+        if isinstance(nt, bytes):
+            nt = nt.decode("utf-8")
+        sparql = (
             f"DROP SILENT GRAPH <{target.graph_iri}> ;\n"
             f"INSERT DATA {{ GRAPH <{target.graph_iri}> {{\n"
-        ).encode("utf-8") + nt + b"\n} }"
-        response = requests.post(
-            target.url,
-            data=update,
-            headers={"Content-Type": "application/sparql-update; charset=utf-8"},
-            auth=target.auth,
-            timeout=target.timeout_seconds,
+            f"{nt}\n"
+            f"}} }}"
         )
-    else:
-        raise ValueError(
-            f"Unsupported push protocol: {target.protocol!r} "
-            f"(expected 'gsp' or 'update')"
-        )
+        backend.update(sparql)
+        return None
 
-    response.raise_for_status()
-    return response
+    raise ValueError(
+        f"Unsupported push protocol: {target.protocol!r} "
+        f"(expected 'gsp' or 'update')"
+    )
 
 
 def target_from_settings(settings_module) -> PushTarget | None:

--- a/home/management/commands/export_rdf.py
+++ b/home/management/commands/export_rdf.py
@@ -93,6 +93,11 @@ class Command(BaseCommand):
             f"(graph: {push_target.graph_iri}, protocol: {push_target.protocol})"
         )
         response = push_graph(data_graph, push_target)
-        self.stdout.write(self.style.SUCCESS(
-            f"  SPARQL push complete: HTTP {response.status_code}"
-        ))
+        # FusekiBackend.update() (the 'update' protocol path) returns
+        # None on success; only the gsp path surfaces a raw Response.
+        if response is not None:
+            self.stdout.write(self.style.SUCCESS(
+                f"  SPARQL push complete: HTTP {response.status_code}"
+            ))
+        else:
+            self.stdout.write(self.style.SUCCESS("  SPARQL push complete"))

--- a/home/management/commands/push_rdf.py
+++ b/home/management/commands/push_rdf.py
@@ -71,6 +71,12 @@ class Command(BaseCommand):
             f" protocol: {push_target.protocol})"
         )
         response = push_graph(graph, push_target)
-        self.stdout.write(self.style.SUCCESS(
-            f"  push complete: HTTP {response.status_code}"
-        ))
+        # The 'update' protocol goes through djangordf's FusekiBackend
+        # which returns None on success; only the gsp path surfaces a
+        # requests.Response.
+        if response is not None:
+            self.stdout.write(self.style.SUCCESS(
+                f"  push complete: HTTP {response.status_code}"
+            ))
+        else:
+            self.stdout.write(self.style.SUCCESS("  push complete"))

--- a/home/tests/test_rdf_push.py
+++ b/home/tests/test_rdf_push.py
@@ -45,28 +45,34 @@ class PushGraphTest(TestCase):
         )
         self.assertIn(b"hello", kwargs["data"])
 
-    def test_update_uses_post_with_sparql_update_body(self):
+    def test_update_routes_through_djangordf_fuseki_backend(self):
+        """The 'update' protocol delegates to djangordf's FusekiBackend
+        so SPARQL writes flow through the JudaicaLink-internal RDF
+        layer instead of plain requests.post()."""
         target = PushTarget(
             url="http://fuseki.example/update",
             graph_iri="http://example.org/g",
             protocol="update",
         )
-        with patch("haskala_rdf.push.requests") as mock_requests:
-            mock_requests.post.return_value.status_code = 200
-            mock_requests.post.return_value.raise_for_status.return_value = None
+        with patch("djangordf.backends.fuseki.FusekiBackend") as MockBackend:
+            instance = MockBackend.return_value
+            instance.update.return_value = None
             push_graph(_sample_graph(), target)
 
-        mock_requests.post.assert_called_once()
-        _args, kwargs = mock_requests.post.call_args
-        self.assertEqual(
-            kwargs["headers"]["Content-Type"],
-            "application/sparql-update; charset=utf-8",
-        )
-        body = kwargs["data"]
-        self.assertIn(b"DROP SILENT GRAPH <http://example.org/g>", body)
-        self.assertIn(b"INSERT DATA", body)
+        # FusekiBackend was instantiated with the dataset root (the
+        # /update suffix is stripped before handing it over).
+        MockBackend.assert_called_once()
+        kwargs = MockBackend.call_args.kwargs
+        self.assertEqual(kwargs["endpoint"], "http://fuseki.example")
+
+        # The backend's update() was called once with a single SPARQL
+        # transaction wrapping DROP + INSERT DATA on the target graph.
+        instance.update.assert_called_once()
+        sparql = instance.update.call_args.args[0]
+        self.assertIn("DROP SILENT GRAPH <http://example.org/g>", sparql)
+        self.assertIn("INSERT DATA", sparql)
         # N-Triples-encoded triple from the sample graph.
-        self.assertIn(b"<http://example.org/s>", body)
+        self.assertIn("<http://example.org/s>", sparql)
 
     def test_basic_auth_threaded_through(self):
         target = PushTarget(

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pyparsing==3.1.1
 pytz==2023.3.post1
 rdflib==7.0.0
 requests==2.33.0
+djangordf==0.4.1
 six==1.16.0
 soupsieve==2.5
 SPARQLWrapper==2.0.0


### PR DESCRIPTION
First production use of the JudaicaLink-internal **djangordf** package. SPARQL writes from Haskala now flow through `djangordf.backends.fuseki.FusekiBackend` so the same library handles RDF writes everywhere in the ecosystem.

## What

- `requirements.txt`: pin `djangordf==0.4.1` (0.4.0 shipped with a broken setup.py; that's the headline feedback delivered to upstream).
- `INSTALLED_APPS`: add `djangordf`.
- `settings/base.py` grows `DJANGORDF_BACKEND` (auto-selects FusekiBackend when `HASKALA_SPARQL_PUSH_URL` is set, falls back to the bundled InMemoryBackend otherwise), `DJANGORDF_DEFAULT_NAMESPACE`, `DJANGORDF_DEFAULT_GRAPH`, `DJANGORDF_NAMESPACES` (hs/hsk/jl/gndo).
- `haskala_rdf/push.py`: when `protocol=update`, instantiate FusekiBackend and call `.update()` with the same DROP+INSERT transaction we used to POST manually. The gsp path stays on raw `requests.put` (djangordf doesn't cover the Graph Store Protocol).
- Test `test_update_routes_through_djangordf_fuseki_backend` patches the backend class to verify the delegation.

## Verified

End-to-end against the dev Fuseki:

```
docker compose exec \
  -e HASKALA_SPARQL_PUSH_URL=http://fuseki:3030/haskala/update \
  -e HASKALA_SPARQL_PUSH_PROTOCOL=update \
  -e HASKALA_SPARQL_PUSH_USER=admin \
  -e HASKALA_SPARQL_PUSH_PASSWORD=admin \
  web python manage.py push_rdf
# → push complete

SELECT (COUNT(*) AS ?n) WHERE {
  GRAPH <http://data.judaicalink.org/data/haskala> { ?s ?p ?o }
}
# → 63100
```

manage.py test 42/42, flake8 clean.

## Upstream feedback delivered

1. Critical packaging bug in djangordf 0.4.0 (`find_packages(include=['djangordf'])` excluded `backends/` and `management/` subpackages on PyPI). Fixed in 0.4.1.
2. Module-level Django settings access — `from djangordf.backends.fuseki import FusekiBackend` fails without `DJANGO_SETTINGS_MODULE` set. Lazier loading would let the backend classes be reusable outside Django apps.
3. `FusekiBackend.update()` returns `None` — asymmetric with `.query()` which returns a `Result`/`Graph`. Returning the underlying `requests.Response` would help callers branch on status.