### PR TITLE
style(theme): visual polish bundle (palette, font, badges, 0.0 cleanup)

### DIFF
--- a/haskala/static/scss/_book_detail.scss
+++ b/haskala/static/scss/_book_detail.scss
@@ -6,7 +6,9 @@
 // person-/place-/topic-/series-/publisher-/occupation- variants.
 
 // Hero header — give the title some breathing room and de-emphasise
-// secondary lines.
+// secondary lines. The header now centers its own action row and
+// keeps Hebrew / Latin alt-titles aligned inside the header block
+// rather than letting them drift into the section grid below.
 .book-header,
 .person-header,
 .place-header,
@@ -17,31 +19,70 @@
   padding-bottom: 1rem;
   border-bottom: 1px solid var(--bs-border-color);
   margin-bottom: 1.5rem;
+  text-align: center;
 
   &__title { line-height: 1.2; }
   &__latin { color: var(--bs-secondary-color); }
-  &__alt { line-height: 1.3; }
+  &__alt {
+    line-height: 1.3;
+    // Hebrew / alt-script lines that aren't tagged with dir="rtl" on
+    // the element still need to sit centered inside the header block,
+    // not bleed into the first section's grid layout below.
+    display: block;
+    margin-top: 0.35rem;
+    direction: rtl;
+    unicode-bidi: isolate;
+    font-size: 1.125rem;
+  }
 
   &__actions {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+    justify-content: center;
+    margin-top: 1rem;
+
+    // Badge-shaped action chips need their own padding because the
+    // .badge utility otherwise renders them flush — and a darker
+    // fill with light text reads better against the warm cream / white
+    // background of the header.
+    .badge,
+    a.badge,
+    a.btn.badge,
+    .book-header__action {
+      padding: 0.5rem 0.85rem;
+      font-size: 0.875rem;
+      line-height: 1.2;
+      color: #fff;
+      background-color: $haskala-black;
+      border-color: $haskala-black;
+
+      &:hover,
+      &:focus {
+        background-color: $haskala-blue;
+        border-color: $haskala-blue;
+        color: #fff;
+      }
+    }
   }
 }
 
 // Person chip — used in the Book header to list authors with their role.
+// Uses !important on padding because Bootstrap's .badge utility (which
+// the chip extends in some templates) sets its own padding that would
+// otherwise win the cascade.
 .person-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.15rem 0.5rem;
+  gap: 0.5rem;
+  padding: 0.45rem 0.95rem !important;
   border-radius: 999px;
   border: 1px solid var(--bs-border-color);
   background: var(--bs-tertiary-bg);
   color: var(--bs-body-color);
   text-decoration: none;
-  font-size: 0.875rem;
-  line-height: 1.2;
+  font-size: 0.92rem;
+  line-height: 1.25;
 
   &:hover,
   &:focus {
@@ -51,8 +92,16 @@
 
   &__role {
     color: var(--bs-secondary-color);
-    font-size: 0.78rem;
+    font-size: 0.82rem;
   }
+}
+
+// Force a readable foreground on Bootstrap's secondary-text-bg badge.
+// Bootstrap's default for .text-bg-secondary picks #000 against a mid
+// grey — passes contrast but reads weak. Use white instead.
+.badge.text-bg-secondary,
+.badge.bg-secondary {
+  color: #fff !important;
 }
 
 // Section spacing on the content column. The first section sits flush

--- a/haskala/static/scss/_layout.scss
+++ b/haskala/static/scss/_layout.scss
@@ -10,7 +10,11 @@ body {
   background-size: 100%;
   overflow-x: hidden;
   font-family: $font-family-base;
-  font-size: small;
+  // 1rem = 16px (set on :root by Bootstrap). The old `font-size: small`
+  // shrunk effective body copy to ~13px which hurt readability on long
+  // catalog pages. Headings + UI continue to scale relative to this.
+  font-size: $font-size-base;
+  line-height: $line-height-base;
   color: $body-color;
   text-align: center;
   padding: 0 $site-padding-x;
@@ -37,11 +41,17 @@ a:hover {
   text-decoration: none;
 }
 
-// Wrapper (Layout-Zentrum)
+// Wrapper (Layout-Zentrum). The default wrapper now uses the wider
+// catalog width; pages that hold long-form legal/cookie text opt into
+// the narrow wrapper so the line length stays under 80 characters.
 .wrapper {
   max-width: $wrapper-max-width;
   margin: 17px auto 14px;
   line-height: 1.7;
+
+  &--narrow {
+    max-width: $wrapper-narrow-max-width;
+  }
 }
 
 // HR-Titel (blaue Linien rechts/links)

--- a/haskala/static/scss/_variables.scss
+++ b/haskala/static/scss/_variables.scss
@@ -1,157 +1,180 @@
 // =========================================================
-// HASKALA COLOR SYSTEM
+// HASKALA COLOR SYSTEM (curated palette, 2026-06)
 // =========================================================
+//
+// Palette taken from the designer's mood boards. The old grey-brown
+// (#615f59) read as washed-out on white; the new base (#5e5d58)
+// keeps the same warm grey character but with a touch more weight,
+// and headings shift to a near-black (#0D0D0D) so titles actually
+// punch out from body copy. The blues swap from teal towards a
+// modern cobalt; gold and wine stay as the heritage accents.
 
-// --- Brand Colors ---
-// Primary text/link colours target WCAG AA (4.5:1) against white. The
-// old #7dbad7 sat at ~2.5:1 and failed; the deeper teal-blue below
-// is ~6.7:1.
-$haskala-brown:      #615f59;  // Hauptschriftfarbe / Grundton
-$haskala-blue:       #1f6e94;  // Linkfarbe / Akzent (kontrastreich)
-$haskala-blue-light: #7dbad7;  // historisches Hellblau, dekorativ
-$haskala-gold:       #a07a2c;  // Hover-Akzent (kontrastreich)
-$haskala-yellow:     #ffcd36;  // Hervorhebung / Warnung (hell)
-$haskala-dark:       #363327;  // Sehr dunkler Kontrastton
+// --- Curated palette (do not edit individual swatches without
+//     updating the moodboard) ---
+$haskala-base:    #5e5d58;  // body text & icons (warm grey)
+$haskala-dark:    #595752;  // hover state for body text / dividers
+$haskala-black:   #0D0D0D;  // headings & high-contrast text
+$haskala-cream:   #F2F1DC;  // page wash / decorative background
 
-// --- Extended Palette (z. B. für Kategorien, Facetten, Hinweise) ---
-$haskala-darkblue: #3e4f57;
-$haskala-beige:    #d6ad7c;
-$haskala-grayblue: #7d8e96;
-$haskala-green:    #a4d67c;
-$haskala-purple:   #d07cd6;
-$haskala-mint:     #7cd6c2;
-$haskala-oliv:     #d6c07c;
+$haskala-blue:    #4992F2;  // primary link / brand
+$haskala-blue-2:  #5F94D9;  // secondary blue (info / muted accents)
+$haskala-cyan:    #82C0D9;  // soft accent / success-ish
+$haskala-violet:  #797FF2;  // info / facets
+
+$haskala-gold:    #A67F38;  // hover accent / warning
+$haskala-red:     #D92B4B;  // danger / strong highlight
+$haskala-wine:    #733C3C;  // heritage accent / book-header trim
+
+// --- Aliases kept for older partials that still reference the
+//     pre-2026 names. New code should reach for the curated names
+//     above. ---
+$haskala-brown:      $haskala-base;
+$haskala-darkblue:   $haskala-blue-2;
+$haskala-blue-light: $haskala-cyan;
+$haskala-yellow:     $haskala-gold;
+$haskala-beige:      $haskala-cream;
+$haskala-grayblue:   $haskala-blue-2;
+$haskala-green:      $haskala-cyan;
+$haskala-purple:     $haskala-violet;
+$haskala-mint:       $haskala-cyan;
+$haskala-oliv:       $haskala-gold;
 
 // =========================================================
 // TYPOGRAPHY
 // =========================================================
+
+// Bump the base font from Bootstrap's 16px-but-with-13px-effective
+// to a clean 16px so body copy is comfortable to read on dense
+// catalog pages. Headings stay relative to this so the whole scale
+// grows together.
+$font-size-base:   1rem;
+$font-size-sm:     0.875rem;
+$font-size-lg:     1.125rem;
+$line-height-base: 1.55;
 
 $font-family-sans-serif: 'open_sansregular', Arial, sans-serif;
 $font-family-base:        $font-family-sans-serif;
 
 $headings-font-family:    'bell_mtbold', $font-family-sans-serif;
 $headings-font-weight:    700;
-$headings-line-height:    1.1;
+$headings-line-height:    1.15;
+$headings-color:          $haskala-black;
 
 // =========================================================
 // GLOBAL COLORS (Bootstrap)
 // =========================================================
 
-// Background + Text
 $body-bg:      #ffffff;
-$body-color:   $haskala-brown; // Haupttextfarbe
+$body-color:   $haskala-base;
 
-// Text and Links
-$link-color:         $haskala-blue;
-$link-hover-color:   $haskala-gold;
-$link-decoration:    none;
+$link-color:            $haskala-blue;
+$link-hover-color:      $haskala-gold;
+$link-decoration:       none;
 $link-hover-decoration: none;
 
-// Borders
-$border-color:       #eae9e7;
-$hr-border-color:    $haskala-brown;
+$border-color:    #eae9e7;
+$hr-border-color: $haskala-base;
 
 // =========================================================
 // BOOTSTRAP THEME OVERRIDES
 // =========================================================
 
-// Primary Theme Colors
 $primary:   $haskala-blue;
-$secondary: $haskala-grayblue;
-$success:   $haskala-green;
-$info:      $haskala-darkblue;
-$warning:   $haskala-yellow;
-$danger:    $haskala-purple;  // du kannst statt Lila auch Rot definieren
+$secondary: $haskala-base;       // dark badges (per request)
+$success:   $haskala-cyan;
+$info:      $haskala-violet;
+$warning:   $haskala-gold;
+$danger:    $haskala-red;
 
-// Bootstrap 4/5
-$primary:   $haskala-blue;
-$secondary: $haskala-grayblue;
-$success:   $haskala-green;
-$info:      $haskala-mint;
-$warning:   $haskala-yellow;
-$danger:    $haskala-purple;
+// Bootstrap 3-Kompatibilität (some older partials still use these)
+$brand-primary: $haskala-blue;
+$brand-success: $haskala-cyan;
+$brand-info:    $haskala-violet;
+$brand-warning: $haskala-gold;
+$brand-danger:  $haskala-red;
 
-// Bootstrap 3-Kompatibilität
-$brand-primary:   $haskala-blue;
-$brand-success:   $haskala-green;
-$brand-info:      $haskala-mint;
-$brand-warning:   $haskala-yellow;
-$brand-danger:    $haskala-purple;
-
-// Buttons konkreter
+// Buttons
 $btn-border-radius: 4px;
-$btn-font-weight:        600;
+$btn-font-weight:   600;
 
-$btn-primary-bg:         $haskala-blue;
-$btn-primary-border:     darken($haskala-blue, 5%);
+$btn-primary-bg:     $haskala-blue;
+$btn-primary-border: darken($haskala-blue, 5%);
 
-$btn-default-bg:         #ffffff;
-$btn-default-color:      $haskala-brown;
-$btn-default-border:     $border-color;
+$btn-default-bg:     #ffffff;
+$btn-default-color:  $haskala-base;
+$btn-default-border: $border-color;
 
-$btn-success-bg:         $haskala-green;
-$btn-success-border:     darken($haskala-green, 5%);
+$btn-success-bg:     $haskala-cyan;
+$btn-success-border: darken($haskala-cyan, 5%);
 
-$btn-info-bg:            $haskala-mint;
-$btn-info-border:        darken($haskala-mint, 5%);
+$btn-info-bg:        $haskala-violet;
+$btn-info-border:    darken($haskala-violet, 5%);
 
-$btn-warning-bg:         $haskala-yellow;
-$btn-warning-border:     darken($haskala-yellow, 5%);
+$btn-warning-bg:     $haskala-gold;
+$btn-warning-border: darken($haskala-gold, 5%);
 
-$btn-danger-bg:          $haskala-purple;
-$btn-danger-border:      darken($haskala-purple, 5%);
+$btn-danger-bg:      $haskala-red;
+$btn-danger-border:  darken($haskala-red, 5%);
 
-// Navbar (falls du Bootstrap-Navigation nutzt)
-$navbar-default-color:                $haskala-brown;
-$navbar-default-link-color:           $haskala-brown;
-$navbar-default-link-hover-color:     $haskala-blue;
-$navbar-default-brand-color:          $haskala-brown;
-$navbar-default-brand-hover-color:    $haskala-blue;
-
+// Navbar
+$navbar-default-color:             $haskala-base;
+$navbar-default-link-color:        $haskala-base;
+$navbar-default-link-hover-color:  $haskala-blue;
+$navbar-default-brand-color:       $haskala-base;
+$navbar-default-brand-hover-color: $haskala-blue;
 
 // Forms
-$input-border-color:      $border-color;
-$input-color:             $haskala-brown;
+$input-border-color: $border-color;
+$input-color:        $haskala-base;
 
 // Tables
-$table-border-color:      $border-color;
+$table-border-color: $border-color;
 
 // Pagination
-$pagination-color:         $haskala-blue;
-$pagination-hover-color:   $haskala-gold;
+$pagination-color:       $haskala-blue;
+$pagination-hover-color: $haskala-gold;
 
-// Cards (Bootstrap 4/5)
-$card-border-color:        $border-color;
+// Cards
+$card-border-color: $border-color;
 
 // =========================================================
 // LAYOUT
 // =========================================================
 
-// Wrapper Layout
-$wrapper-max-width: 950px;
-$site-padding-x:    20px;
+// Wider wrapper so the catalog detail pages don't squeeze rich
+// definition lists into a narrow column on desktop. Legal pages
+// get their own narrow wrapper via .container--narrow below.
+$wrapper-max-width: 1280px;
+$wrapper-narrow-max-width: 760px;
+$site-padding-x:    24px;
 
 // =========================================================
-// OPTIONAL: CUSTOM COLOR MAP (für spätere automatische Generierung)
+// Custom colour map (kept for legacy callers + future generation)
 // =========================================================
-
-// Diese Map erlaubt dir, für Kategorien oder Facettengruppen sofort Farben zuzuweisen.
 
 $haskala-color-map: (
-  "brown":     $haskala-brown,
-  "blue":      $haskala-blue,
-  "gold":      $haskala-gold,
-  "yellow":    $haskala-yellow,
-  "dark":      $haskala-dark,
-  "darkblue":  $haskala-darkblue,
-  "beige":     $haskala-beige,
-  "grayblue":  $haskala-grayblue,
-  "green":     $haskala-green,
-  "purple":    $haskala-purple,
-  "mint":      $haskala-mint,
-  "oliv":      $haskala-oliv,
+  "base":     $haskala-base,
+  "dark":     $haskala-dark,
+  "black":    $haskala-black,
+  "cream":    $haskala-cream,
+  "blue":     $haskala-blue,
+  "blue-2":   $haskala-blue-2,
+  "cyan":     $haskala-cyan,
+  "violet":   $haskala-violet,
+  "gold":     $haskala-gold,
+  "red":      $haskala-red,
+  "wine":     $haskala-wine,
+  // legacy aliases:
+  "brown":    $haskala-base,
+  "yellow":   $haskala-gold,
+  "darkblue": $haskala-blue-2,
+  "beige":    $haskala-cream,
+  "grayblue": $haskala-blue-2,
+  "green":    $haskala-cyan,
+  "purple":   $haskala-violet,
+  "mint":     $haskala-cyan,
+  "oliv":     $haskala-gold,
 );
-
 
 @function color($name) {
   @return map-get($haskala-color-map, $name);

--- a/haskala/templates/books/_sections/authors.html
+++ b/haskala/templates/books/_sections/authors.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 {% if book.bookauthor_set.all %}
     <h3 class="h6 mt-3">Persons</h3>
     <ul class="list-unstyled mb-3">
@@ -15,28 +16,28 @@
 {% endif %}
 
 <dl class="row mb-0">
-    {% if book.original_author %}
+    {% if book.original_author|clean_value %}
         <dt class="col-sm-4">Original author</dt>
-        <dd class="col-sm-8">{{ book.original_author }}</dd>
+        <dd class="col-sm-8">{{ book.original_author|clean_value }}</dd>
     {% endif %}
-    {% if book.original_author_else_refer %}
+    {% if book.original_author_else_refer|clean_value %}
         <dt class="col-sm-4">Original author (reference)</dt>
-        <dd class="col-sm-8">{{ book.original_author_else_refer }}</dd>
+        <dd class="col-sm-8">{{ book.original_author_else_refer|clean_value }}</dd>
     {% endif %}
-    {% if book.original_author_elsewhere %}
+    {% if book.original_author_elsewhere|clean_value %}
         <dt class="col-sm-4">Original author elsewhere</dt>
-        <dd class="col-sm-8">{{ book.original_author_elsewhere }}</dd>
+        <dd class="col-sm-8">{{ book.original_author_elsewhere|clean_value }}</dd>
     {% endif %}
-    {% if book.original_author_other_name %}
+    {% if book.original_author_other_name|clean_value %}
         <dt class="col-sm-4">Original author (other name)</dt>
-        <dd class="col-sm-8">{{ book.original_author_other_name }}</dd>
+        <dd class="col-sm-8">{{ book.original_author_other_name|clean_value }}</dd>
     {% endif %}
-    {% if book.founders %}
+    {% if book.founders|clean_value %}
         <dt class="col-sm-4">Founders</dt>
-        <dd class="col-sm-8">{{ book.founders }}</dd>
+        <dd class="col-sm-8">{{ book.founders|clean_value }}</dd>
     {% endif %}
-    {% if book.proofreaders %}
+    {% if book.proofreaders|clean_value %}
         <dt class="col-sm-4">Proofreaders</dt>
-        <dd class="col-sm-8">{{ book.proofreaders }}</dd>
+        <dd class="col-sm-8">{{ book.proofreaders|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/availability.html
+++ b/haskala/templates/books/_sections/availability.html
@@ -1,28 +1,29 @@
+{% load value_filters %}
 {% load utils %}
 <dl class="row mb-0">
-    {% if book.not_available %}
+    {% if book.not_available|clean_value %}
         <dt class="col-sm-4">Availability</dt>
         <dd class="col-sm-8"><span class="text-warning">Not currently available</span></dd>
     {% endif %}
-    {% if book.availability_notes %}
+    {% if book.availability_notes|clean_value %}
         <dt class="col-sm-4">Availability notes</dt>
-        <dd class="col-sm-8">{{ book.availability_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.availability_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.digital_book_url %}
+    {% if book.digital_book_url|clean_value %}
         <dt class="col-sm-4">Digital copy</dt>
         <dd class="col-sm-8">
-            <a href="{{ book.digital_book_url }}" target="_blank" rel="noopener">
+            <a href="{{ book.digital_book_url|clean_value }}" target="_blank" rel="noopener">
                 {{ book.digital_book_title|default:"Open digital copy" }}
                 <i class="bi bi-box-arrow-up-right small"></i>
             </a>
-            {% if book.digital_book_attributes %}
-                <div class="small text-muted">{{ book.digital_book_attributes }}</div>
+            {% if book.digital_book_attributes|clean_value %}
+                <div class="small text-muted">{{ book.digital_book_attributes|clean_value }}</div>
             {% endif %}
         </dd>
     {% endif %}
-    {% if book.other_libraries %}
+    {% if book.other_libraries|clean_value %}
         <dt class="col-sm-4">Other libraries</dt>
-        <dd class="col-sm-8">{{ book.other_libraries|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.other_libraries|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>
 
@@ -50,12 +51,12 @@
 {% endif %}
 
 <dl class="row mb-0 mt-3">
-    {% if book.preservation_references %}
+    {% if book.preservation_references|clean_value %}
         <dt class="col-sm-4">Preservation references</dt>
-        <dd class="col-sm-8">{{ book.preservation_references|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.preservation_references|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.catalog_numbers_notes %}
+    {% if book.catalog_numbers_notes|clean_value %}
         <dt class="col-sm-4">Catalog number notes</dt>
-        <dd class="col-sm-8">{{ book.catalog_numbers_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.catalog_numbers_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/censorship.html
+++ b/haskala/templates/books/_sections/censorship.html
@@ -1,18 +1,19 @@
+{% load value_filters %}
 <dl class="row mb-0">
-    {% if book.censorship %}
+    {% if book.censorship|clean_value %}
         <dt class="col-sm-4">Censorship</dt>
-        <dd class="col-sm-8">{{ book.censorship|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.censorship|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.bans %}
+    {% if book.bans|clean_value %}
         <dt class="col-sm-4">Bans</dt>
-        <dd class="col-sm-8">{{ book.bans|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.bans|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.rabbinical_approbations %}
+    {% if book.rabbinical_approbations|clean_value %}
         <dt class="col-sm-4">Rabbinical approbations</dt>
-        <dd class="col-sm-8">{{ book.rabbinical_approbations|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.rabbinical_approbations|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.rabbinical_approbation_notes %}
+    {% if book.rabbinical_approbation_notes|clean_value %}
         <dt class="col-sm-4">Approbation notes</dt>
-        <dd class="col-sm-8">{{ book.rabbinical_approbation_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.rabbinical_approbation_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/content_structure.html
+++ b/haskala/templates/books/_sections/content_structure.html
@@ -1,5 +1,6 @@
+{% load value_filters %}
 <dl class="row mb-0">
-    {% if book.topic %}
+    {% if book.topic|clean_value %}
         <dt class="col-sm-4">Topic</dt>
         <dd class="col-sm-8">
             <a href="{% url 'topic-detail' book.topic.name|slugify %}">{{ book.topic.name }}</a>
@@ -11,11 +12,11 @@
             {% for ta in book.target_audience.all %}{{ ta.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
-    {% if book.target_audience_notes %}
+    {% if book.target_audience_notes|clean_value %}
         <dt class="col-sm-4">Target audience notes</dt>
-        <dd class="col-sm-8">{{ book.target_audience_notes }}</dd>
+        <dd class="col-sm-8">{{ book.target_audience_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.original_type %}
+    {% if book.original_type|clean_value %}
         <dt class="col-sm-4">Original type</dt>
         <dd class="col-sm-8">{{ book.original_type.name }}</dd>
     {% endif %}
@@ -31,44 +32,44 @@
             {% for tm in book.secondary_textual_models.all %}{{ tm.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
-    {% if book.textual_model_notes %}
+    {% if book.textual_model_notes|clean_value %}
         <dt class="col-sm-4">Textual model notes</dt>
-        <dd class="col-sm-8">{{ book.textual_model_notes }}</dd>
+        <dd class="col-sm-8">{{ book.textual_model_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.structure_notes %}
+    {% if book.structure_notes|clean_value %}
         <dt class="col-sm-4">Structure notes</dt>
-        <dd class="col-sm-8">{{ book.structure_notes }}</dd>
+        <dd class="col-sm-8">{{ book.structure_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.structure_preface_notes %}
+    {% if book.structure_preface_notes|clean_value %}
         <dt class="col-sm-4">Structure / preface notes</dt>
-        <dd class="col-sm-8">{{ book.structure_preface_notes }}</dd>
+        <dd class="col-sm-8">{{ book.structure_preface_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.table_of_content %}
+    {% if book.table_of_content|clean_value %}
         <dt class="col-sm-4">Table of contents</dt>
-        <dd class="col-sm-8">{{ book.table_of_content|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.table_of_content|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.contents_table_notes %}
+    {% if book.contents_table_notes|clean_value %}
         <dt class="col-sm-4">Table of contents notes</dt>
-        <dd class="col-sm-8">{{ book.contents_table_notes }}</dd>
+        <dd class="col-sm-8">{{ book.contents_table_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.preface %}
+    {% if book.preface|clean_value %}
         <dt class="col-sm-4">Preface</dt>
-        <dd class="col-sm-8">{{ book.preface|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.preface|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.epilogue %}
+    {% if book.epilogue|clean_value %}
         <dt class="col-sm-4">Epilogue</dt>
-        <dd class="col-sm-8">{{ book.epilogue|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.epilogue|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.epilogue_notes %}
+    {% if book.epilogue_notes|clean_value %}
         <dt class="col-sm-4">Epilogue notes</dt>
-        <dd class="col-sm-8">{{ book.epilogue_notes }}</dd>
+        <dd class="col-sm-8">{{ book.epilogue_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.dedications %}
+    {% if book.dedications|clean_value %}
         <dt class="col-sm-4">Dedications</dt>
-        <dd class="col-sm-8">{{ book.dedications|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.dedications|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.dedications_notes %}
+    {% if book.dedications_notes|clean_value %}
         <dt class="col-sm-4">Dedications notes</dt>
-        <dd class="col-sm-8">{{ book.dedications_notes }}</dd>
+        <dd class="col-sm-8">{{ book.dedications_notes|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/editions.html
+++ b/haskala/templates/books/_sections/editions.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 {% if book.editions.all %}
     <h3 class="h6 mt-3">Known editions</h3>
     <ul class="list-unstyled mb-3">
@@ -13,68 +14,68 @@
 {% endif %}
 
 <dl class="row mb-0">
-    {% if book.total_number_of_editions %}
+    {% if book.total_number_of_editions|clean_value %}
         <dt class="col-sm-4">Total number of editions</dt>
-        <dd class="col-sm-8">{{ book.total_number_of_editions }}</dd>
+        <dd class="col-sm-8">{{ book.total_number_of_editions|clean_value }}</dd>
     {% endif %}
-    {% if book.last_known_edition %}
+    {% if book.last_known_edition|clean_value %}
         <dt class="col-sm-4">Last known edition</dt>
-        <dd class="col-sm-8">{{ book.last_known_edition }}</dd>
+        <dd class="col-sm-8">{{ book.last_known_edition|clean_value }}</dd>
     {% endif %}
-    {% if book.editions_notes %}
+    {% if book.editions_notes|clean_value %}
         <dt class="col-sm-4">Editions notes</dt>
-        <dd class="col-sm-8">{{ book.editions_notes }}</dd>
+        <dd class="col-sm-8">{{ book.editions_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.references_for_editions %}
+    {% if book.references_for_editions|clean_value %}
         <dt class="col-sm-4">References for editions</dt>
-        <dd class="col-sm-8">{{ book.references_for_editions }}</dd>
+        <dd class="col-sm-8">{{ book.references_for_editions|clean_value }}</dd>
     {% endif %}
-    {% if book.new_edition_general_notes %}
+    {% if book.new_edition_general_notes|clean_value %}
         <dt class="col-sm-4">New edition notes</dt>
-        <dd class="col-sm-8">{{ book.new_edition_general_notes }}</dd>
+        <dd class="col-sm-8">{{ book.new_edition_general_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.new_edition_type_in_text %}
+    {% if book.new_edition_type_in_text|clean_value %}
         <dt class="col-sm-4">New edition type (in book)</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_in_text }}</dd>
+        <dd class="col-sm-8">{{ book.new_edition_type_in_text|clean_value }}</dd>
     {% endif %}
-    {% if book.new_edition_type_elsewhere %}
+    {% if book.new_edition_type_elsewhere|clean_value %}
         <dt class="col-sm-4">New edition type (elsewhere)</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_elsewhere }}</dd>
+        <dd class="col-sm-8">{{ book.new_edition_type_elsewhere|clean_value }}</dd>
     {% endif %}
-    {% if book.new_edition_type_reference %}
+    {% if book.new_edition_type_reference|clean_value %}
         <dt class="col-sm-4">New edition type reference</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_reference }}</dd>
+        <dd class="col-sm-8">{{ book.new_edition_type_reference|clean_value }}</dd>
     {% endif %}
-    {% if book.new_edition_type_else_ref %}
+    {% if book.new_edition_type_else_ref|clean_value %}
         <dt class="col-sm-4">New edition type (other reference)</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_else_ref }}</dd>
+        <dd class="col-sm-8">{{ book.new_edition_type_else_ref|clean_value }}</dd>
     {% endif %}
-    {% if book.new_edition_type_notes %}
+    {% if book.new_edition_type_notes|clean_value %}
         <dt class="col-sm-4">New edition type notes</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_notes }}</dd>
+        <dd class="col-sm-8">{{ book.new_edition_type_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.new_edition_type_else_note %}
+    {% if book.new_edition_type_else_note|clean_value %}
         <dt class="col-sm-4">New edition type (other notes)</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_else_note }}</dd>
+        <dd class="col-sm-8">{{ book.new_edition_type_else_note|clean_value }}</dd>
     {% endif %}
-    {% if book.copy_of_book_used %}
+    {% if book.copy_of_book_used|clean_value %}
         <dt class="col-sm-4">Copy of book used</dt>
-        <dd class="col-sm-8">{{ book.copy_of_book_used }}</dd>
+        <dd class="col-sm-8">{{ book.copy_of_book_used|clean_value }}</dd>
     {% endif %}
-    {% if book.other_volumes %}
+    {% if book.other_volumes|clean_value %}
         <dt class="col-sm-4">Other volumes</dt>
-        <dd class="col-sm-8">{{ book.other_volumes }}</dd>
+        <dd class="col-sm-8">{{ book.other_volumes|clean_value }}</dd>
     {% endif %}
-    {% if book.volumes_notes %}
+    {% if book.volumes_notes|clean_value %}
         <dt class="col-sm-4">Volume notes</dt>
-        <dd class="col-sm-8">{{ book.volumes_notes }}</dd>
+        <dd class="col-sm-8">{{ book.volumes_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.volumes_published_number %}
+    {% if book.volumes_published_number|clean_value %}
         <dt class="col-sm-4">Volumes published</dt>
-        <dd class="col-sm-8">{{ book.volumes_published_number }}</dd>
+        <dd class="col-sm-8">{{ book.volumes_published_number|clean_value }}</dd>
     {% endif %}
-    {% if book.planned_volumes %}
+    {% if book.planned_volumes|clean_value %}
         <dt class="col-sm-4">Planned volumes</dt>
-        <dd class="col-sm-8">{{ book.planned_volumes }}</dd>
+        <dd class="col-sm-8">{{ book.planned_volumes|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/identity.html
+++ b/haskala/templates/books/_sections/identity.html
@@ -1,50 +1,51 @@
+{% load value_filters %}
 <dl class="row mb-0">
-    {% if book.full_title %}
+    {% if book.full_title|clean_value %}
         <dt class="col-sm-4">Full title</dt>
-        <dd class="col-sm-8">{{ book.full_title }}</dd>
+        <dd class="col-sm-8">{{ book.full_title|clean_value }}</dd>
     {% endif %}
-    {% if book.title_in_latin_characters %}
+    {% if book.title_in_latin_characters|clean_value %}
         <dt class="col-sm-4">Title in Latin characters</dt>
-        <dd class="col-sm-8 fst-italic">{{ book.title_in_latin_characters }}</dd>
+        <dd class="col-sm-8 fst-italic">{{ book.title_in_latin_characters|clean_value }}</dd>
     {% endif %}
-    {% if book.motto %}
+    {% if book.motto|clean_value %}
         <dt class="col-sm-4">Motto</dt>
-        <dd class="col-sm-8">{{ book.motto }}</dd>
+        <dd class="col-sm-8">{{ book.motto|clean_value }}</dd>
     {% endif %}
-    {% if book.old_name_in_book %}
+    {% if book.old_name_in_book|clean_value %}
         <dt class="col-sm-4">Old name in book</dt>
-        <dd class="col-sm-8">{{ book.old_name_in_book }}</dd>
+        <dd class="col-sm-8">{{ book.old_name_in_book|clean_value }}</dd>
     {% endif %}
-    {% if book.other_books_names %}
+    {% if book.other_books_names|clean_value %}
         <dt class="col-sm-4">Other names of this book</dt>
-        <dd class="col-sm-8">{{ book.other_books_names }}</dd>
+        <dd class="col-sm-8">{{ book.other_books_names|clean_value }}</dd>
     {% endif %}
-    {% if book.original_text_name %}
+    {% if book.original_text_name|clean_value %}
         <dt class="col-sm-4">Original text name</dt>
-        <dd class="col-sm-8">{{ book.original_text_name }}</dd>
+        <dd class="col-sm-8">{{ book.original_text_name|clean_value }}</dd>
     {% endif %}
-    {% if book.original_title %}
+    {% if book.original_title|clean_value %}
         <dt class="col-sm-4">Original title</dt>
-        <dd class="col-sm-8">{{ book.original_title }}</dd>
+        <dd class="col-sm-8">{{ book.original_title|clean_value }}</dd>
     {% endif %}
-    {% if book.original_title_else_refer %}
+    {% if book.original_title_else_refer|clean_value %}
         <dt class="col-sm-4">Original title (reference)</dt>
-        <dd class="col-sm-8">{{ book.original_title_else_refer }}</dd>
+        <dd class="col-sm-8">{{ book.original_title_else_refer|clean_value }}</dd>
     {% endif %}
-    {% if book.original_title_elsewhere %}
+    {% if book.original_title_elsewhere|clean_value %}
         <dt class="col-sm-4">Original title elsewhere</dt>
-        <dd class="col-sm-8">{{ book.original_title_elsewhere }}</dd>
+        <dd class="col-sm-8">{{ book.original_title_elsewhere|clean_value }}</dd>
     {% endif %}
-    {% if book.presented_as_original %}
+    {% if book.presented_as_original|clean_value %}
         <dt class="col-sm-4">Presented as original</dt>
-        <dd class="col-sm-8">{{ book.presented_as_original }}</dd>
+        <dd class="col-sm-8">{{ book.presented_as_original|clean_value }}</dd>
     {% endif %}
-    {% if book.presented_as_translation %}
+    {% if book.presented_as_translation|clean_value %}
         <dt class="col-sm-4">Presented as translation</dt>
-        <dd class="col-sm-8">{{ book.presented_as_translation }}</dd>
+        <dd class="col-sm-8">{{ book.presented_as_translation|clean_value }}</dd>
     {% endif %}
-    {% if book.presented_new_edition %}
+    {% if book.presented_new_edition|clean_value %}
         <dt class="col-sm-4">Presented as new edition</dt>
-        <dd class="col-sm-8">{{ book.presented_new_edition }}</dd>
+        <dd class="col-sm-8">{{ book.presented_new_edition|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/languages.html
+++ b/haskala/templates/books/_sections/languages.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 <dl class="row mb-0">
     {% if book.languages.all %}
         <dt class="col-sm-4">Languages</dt>
@@ -5,11 +6,11 @@
             {% for lang in book.languages.all %}{{ lang.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
-    {% if book.original_language %}
+    {% if book.original_language|clean_value %}
         <dt class="col-sm-4">Original language</dt>
         <dd class="col-sm-8">{{ book.original_language.name }}</dd>
     {% endif %}
-    {% if book.languages_number %}
+    {% if book.languages_number|clean_value %}
         <dt class="col-sm-4">Number of languages</dt>
         <dd class="col-sm-8">{{ book.languages_number.name }}</dd>
     {% endif %}
@@ -19,7 +20,7 @@
             {% for lang in book.footnote_languages.all %}{{ lang.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
-    {% if book.location_of_footnotes %}
+    {% if book.location_of_footnotes|clean_value %}
         <dt class="col-sm-4">Location of footnotes</dt>
         <dd class="col-sm-8">{{ book.location_of_footnotes.name }}</dd>
     {% endif %}

--- a/haskala/templates/books/_sections/mentions.html
+++ b/haskala/templates/books/_sections/mentions.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 {% if book.mentions.all %}
     <ul class="list-unstyled mb-3">
         {% for m in book.mentions.all %}
@@ -22,24 +23,24 @@
 {% endif %}
 
 <dl class="row mb-0">
-    {% if book.mention_general_notes %}
+    {% if book.mention_general_notes|clean_value %}
         <dt class="col-sm-4">General mention notes</dt>
-        <dd class="col-sm-8">{{ book.mention_general_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.mention_general_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.mentions_in_reviews %}
+    {% if book.mentions_in_reviews|clean_value %}
         <dt class="col-sm-4">Mentions in reviews</dt>
-        <dd class="col-sm-8">{{ book.mentions_in_reviews|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.mentions_in_reviews|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.contemporary_disputes %}
+    {% if book.contemporary_disputes|clean_value %}
         <dt class="col-sm-4">Contemporary disputes</dt>
-        <dd class="col-sm-8">{{ book.contemporary_disputes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.contemporary_disputes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.contemporary_references %}
+    {% if book.contemporary_references|clean_value %}
         <dt class="col-sm-4">Contemporary references</dt>
-        <dd class="col-sm-8">{{ book.contemporary_references|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.contemporary_references|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.later_references %}
+    {% if book.later_references|clean_value %}
         <dt class="col-sm-4">Later references</dt>
-        <dd class="col-sm-8">{{ book.later_references|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.later_references|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/physical.html
+++ b/haskala/templates/books/_sections/physical.html
@@ -1,17 +1,18 @@
+{% load value_filters %}
 <dl class="row mb-0">
-    {% if book.pages_number %}
+    {% if book.pages_number|clean_value %}
         <dt class="col-sm-4">Pages</dt>
-        <dd class="col-sm-8">{{ book.pages_number }}</dd>
+        <dd class="col-sm-8">{{ book.pages_number|clean_value }}</dd>
     {% endif %}
-    {% if book.height %}
+    {% if book.height|clean_value %}
         <dt class="col-sm-4">Height</dt>
-        <dd class="col-sm-8">{{ book.height }}</dd>
+        <dd class="col-sm-8">{{ book.height|clean_value }}</dd>
     {% endif %}
-    {% if book.width %}
+    {% if book.width|clean_value %}
         <dt class="col-sm-4">Width</dt>
-        <dd class="col-sm-8">{{ book.width }}</dd>
+        <dd class="col-sm-8">{{ book.width|clean_value }}</dd>
     {% endif %}
-    {% if book.alignment %}
+    {% if book.alignment|clean_value %}
         <dt class="col-sm-4">Alignment</dt>
         <dd class="col-sm-8">{{ book.alignment.name }}</dd>
     {% endif %}
@@ -27,16 +28,16 @@
             {% for t in book.typography.all %}{{ t.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
-    {% if book.illustrations_diagrams %}
+    {% if book.illustrations_diagrams|clean_value %}
         <dt class="col-sm-4">Illustrations / diagrams</dt>
-        <dd class="col-sm-8">{{ book.illustrations_diagrams }}</dd>
+        <dd class="col-sm-8">{{ book.illustrations_diagrams|clean_value }}</dd>
     {% endif %}
-    {% if book.diagrams_notes %}
+    {% if book.diagrams_notes|clean_value %}
         <dt class="col-sm-4">Diagram notes</dt>
-        <dd class="col-sm-8">{{ book.diagrams_notes }}</dd>
+        <dd class="col-sm-8">{{ book.diagrams_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.diagrams_book_pages %}
+    {% if book.diagrams_book_pages|clean_value %}
         <dt class="col-sm-4">Diagram book pages</dt>
-        <dd class="col-sm-8">{{ book.diagrams_book_pages }}</dd>
+        <dd class="col-sm-8">{{ book.diagrams_book_pages|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/prefaces.html
+++ b/haskala/templates/books/_sections/prefaces.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for pf in book.prefaces.all %}
         <li class="mb-2">

--- a/haskala/templates/books/_sections/productions.html
+++ b/haskala/templates/books/_sections/productions.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for prod in book.productions.all %}
         <li class="mb-2">

--- a/haskala/templates/books/_sections/publication.html
+++ b/haskala/templates/books/_sections/publication.html
@@ -1,5 +1,6 @@
+{% load value_filters %}
 <dl class="row mb-0">
-    {% if book.publisher %}
+    {% if book.publisher|clean_value %}
         <dt class="col-sm-4">Publisher</dt>
         <dd class="col-sm-8">
             {% if book.publisher.slug %}
@@ -9,7 +10,7 @@
             {% endif %}
         </dd>
     {% endif %}
-    {% if book.original_publisher %}
+    {% if book.original_publisher|clean_value %}
         <dt class="col-sm-4">Original publisher</dt>
         <dd class="col-sm-8">
             {% if book.original_publisher.slug %}
@@ -19,7 +20,7 @@
             {% endif %}
         </dd>
     {% endif %}
-    {% if book.publication_place %}
+    {% if book.publication_place|clean_value %}
         <dt class="col-sm-4">Publication place</dt>
         <dd class="col-sm-8">
             <a href="{% url 'place-detail' book.publication_place.slug %}">
@@ -27,47 +28,47 @@
             </a>
         </dd>
     {% endif %}
-    {% if book.publication_place_other %}
+    {% if book.publication_place_other|clean_value %}
         <dt class="col-sm-4">Other publication place</dt>
         <dd class="col-sm-8">{{ book.publication_place_other.name }}</dd>
     {% endif %}
-    {% if book.gregorian_year %}
+    {% if book.gregorian_year|clean_value %}
         <dt class="col-sm-4">Year (Gregorian)</dt>
-        <dd class="col-sm-8">{{ book.gregorian_year }}</dd>
+        <dd class="col-sm-8">{{ book.gregorian_year|clean_value }}</dd>
     {% endif %}
-    {% if book.year_in_book %}
+    {% if book.year_in_book|clean_value %}
         <dt class="col-sm-4">Year as in book</dt>
-        <dd class="col-sm-8">{{ book.year_in_book }}</dd>
+        <dd class="col-sm-8">{{ book.year_in_book|clean_value }}</dd>
     {% endif %}
-    {% if book.year_in_other %}
+    {% if book.year_in_other|clean_value %}
         <dt class="col-sm-4">Year (other reference)</dt>
-        <dd class="col-sm-8">{{ book.year_in_other }}</dd>
+        <dd class="col-sm-8">{{ book.year_in_other|clean_value }}</dd>
     {% endif %}
-    {% if book.hebrew_year_of_publication %}
+    {% if book.hebrew_year_of_publication|clean_value %}
         <dt class="col-sm-4">Hebrew year of publication</dt>
-        <dd class="col-sm-8">{{ book.hebrew_year_of_publication }}</dd>
+        <dd class="col-sm-8">{{ book.hebrew_year_of_publication|clean_value }}</dd>
     {% endif %}
-    {% if book.hebrew_year_pub_other %}
+    {% if book.hebrew_year_pub_other|clean_value %}
         <dt class="col-sm-4">Hebrew year (other reference)</dt>
-        <dd class="col-sm-8">{{ book.hebrew_year_pub_other }}</dd>
+        <dd class="col-sm-8">{{ book.hebrew_year_pub_other|clean_value }}</dd>
     {% endif %}
-    {% if book.gregorian_year_pub_other %}
+    {% if book.gregorian_year_pub_other|clean_value %}
         <dt class="col-sm-4">Gregorian year (other reference)</dt>
-        <dd class="col-sm-8">{{ book.gregorian_year_pub_other }}</dd>
+        <dd class="col-sm-8">{{ book.gregorian_year_pub_other|clean_value }}</dd>
     {% endif %}
-    {% if book.format_of_publication_date %}
+    {% if book.format_of_publication_date|clean_value %}
         <dt class="col-sm-4">Format of publication date</dt>
         <dd class="col-sm-8">{{ book.format_of_publication_date.name }}</dd>
     {% endif %}
-    {% if book.partial_publication %}
+    {% if book.partial_publication|clean_value %}
         <dt class="col-sm-4">Partial publication</dt>
-        <dd class="col-sm-8">{{ book.partial_publication }}</dd>
+        <dd class="col-sm-8">{{ book.partial_publication|clean_value }}</dd>
     {% endif %}
-    {% if book.printed_originally %}
+    {% if book.printed_originally|clean_value %}
         <dt class="col-sm-4">Printed originally</dt>
-        <dd class="col-sm-8">{{ book.printed_originally }}</dd>
+        <dd class="col-sm-8">{{ book.printed_originally|clean_value }}</dd>
     {% endif %}
-    {% if book.original_publication_place %}
+    {% if book.original_publication_place|clean_value %}
         <dt class="col-sm-4">Original publication place</dt>
         <dd class="col-sm-8">
             <a href="{% url 'place-detail' book.original_publication_place.slug %}">
@@ -75,27 +76,27 @@
             </a>
         </dd>
     {% endif %}
-    {% if book.original_publication_year %}
+    {% if book.original_publication_year|clean_value %}
         <dt class="col-sm-4">Original publication year</dt>
-        <dd class="col-sm-8">{{ book.original_publication_year }}</dd>
+        <dd class="col-sm-8">{{ book.original_publication_year|clean_value }}</dd>
     {% endif %}
-    {% if book.printers %}
+    {% if book.printers|clean_value %}
         <dt class="col-sm-4">Printers</dt>
-        <dd class="col-sm-8">{{ book.printers }}</dd>
+        <dd class="col-sm-8">{{ book.printers|clean_value }}</dd>
     {% endif %}
-    {% if book.printing_press_notes %}
+    {% if book.printing_press_notes|clean_value %}
         <dt class="col-sm-4">Printing press notes</dt>
-        <dd class="col-sm-8">{{ book.printing_press_notes }}</dd>
+        <dd class="col-sm-8">{{ book.printing_press_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.printing_press_references %}
+    {% if book.printing_press_references|clean_value %}
         <dt class="col-sm-4">Printing press references</dt>
-        <dd class="col-sm-8">{{ book.printing_press_references }}</dd>
+        <dd class="col-sm-8">{{ book.printing_press_references|clean_value }}</dd>
     {% endif %}
-    {% if book.production_evidence %}
+    {% if book.production_evidence|clean_value %}
         <dt class="col-sm-4">Production evidence</dt>
-        <dd class="col-sm-8">{{ book.production_evidence }}</dd>
+        <dd class="col-sm-8">{{ book.production_evidence|clean_value }}</dd>
     {% endif %}
-    {% if book.series %}
+    {% if book.series|clean_value %}
         <dt class="col-sm-4">Series</dt>
         <dd class="col-sm-8">
             {% if book.series.slug %}
@@ -103,10 +104,10 @@
             {% else %}
                 {{ book.series.name }}
             {% endif %}
-            {% if book.series_part %}<span class="text-muted small">&middot; part {{ book.series_part }}</span>{% endif %}
+            {% if book.series_part|clean_value %}<span class="text-muted small">&middot; part {{ book.series_part|clean_value }}</span>{% endif %}
         </dd>
     {% elif book.series_part %}
         <dt class="col-sm-4">Series part</dt>
-        <dd class="col-sm-8">{{ book.series_part }}</dd>
+        <dd class="col-sm-8">{{ book.series_part|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/sources.html
+++ b/haskala/templates/books/_sections/sources.html
@@ -1,54 +1,55 @@
+{% load value_filters %}
 <dl class="row mb-0">
-    {% if book.bibliographical_citations %}
+    {% if book.bibliographical_citations|clean_value %}
         <dt class="col-sm-4">Bibliographical citations</dt>
-        <dd class="col-sm-8">{{ book.bibliographical_citations|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.bibliographical_citations|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.studies %}
+    {% if book.studies|clean_value %}
         <dt class="col-sm-4">Studies</dt>
-        <dd class="col-sm-8">{{ book.studies|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.studies|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.sources_exist %}
+    {% if book.sources_exist|clean_value %}
         <dt class="col-sm-4">Sources exist</dt>
-        <dd class="col-sm-8">{{ book.sources_exist }}</dd>
+        <dd class="col-sm-8">{{ book.sources_exist|clean_value }}</dd>
     {% endif %}
-    {% if book.sources_list %}
+    {% if book.sources_list|clean_value %}
         <dt class="col-sm-4">Sources</dt>
-        <dd class="col-sm-8">{{ book.sources_list|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.sources_list|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.sources_not_mentioned %}
+    {% if book.sources_not_mentioned|clean_value %}
         <dt class="col-sm-4">Sources not mentioned in book</dt>
-        <dd class="col-sm-8">{{ book.sources_not_mentioned }}</dd>
+        <dd class="col-sm-8">{{ book.sources_not_mentioned|clean_value }}</dd>
     {% endif %}
-    {% if book.sources_not_mentioned_list %}
+    {% if book.sources_not_mentioned_list|clean_value %}
         <dt class="col-sm-4">Sources not mentioned (list)</dt>
-        <dd class="col-sm-8">{{ book.sources_not_mentioned_list|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.sources_not_mentioned_list|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.sources_not_mentioned_ref %}
+    {% if book.sources_not_mentioned_ref|clean_value %}
         <dt class="col-sm-4">Sources not mentioned (reference)</dt>
-        <dd class="col-sm-8">{{ book.sources_not_mentioned_ref }}</dd>
+        <dd class="col-sm-8">{{ book.sources_not_mentioned_ref|clean_value }}</dd>
     {% endif %}
-    {% if book.sources_references %}
+    {% if book.sources_references|clean_value %}
         <dt class="col-sm-4">Source references</dt>
-        <dd class="col-sm-8">{{ book.sources_references|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.sources_references|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.jewish_sources_quotes %}
+    {% if book.jewish_sources_quotes|clean_value %}
         <dt class="col-sm-4">Quotes from Jewish sources</dt>
-        <dd class="col-sm-8">{{ book.jewish_sources_quotes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.jewish_sources_quotes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.non_jewish_sources_quotes %}
+    {% if book.non_jewish_sources_quotes|clean_value %}
         <dt class="col-sm-4">Quotes from non-Jewish sources</dt>
-        <dd class="col-sm-8">{{ book.non_jewish_sources_quotes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.non_jewish_sources_quotes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.original_sources_mention %}
+    {% if book.original_sources_mention|clean_value %}
         <dt class="col-sm-4">Original source mention</dt>
-        <dd class="col-sm-8">{{ book.original_sources_mention }}</dd>
+        <dd class="col-sm-8">{{ book.original_sources_mention|clean_value }}</dd>
     {% endif %}
-    {% if book.references_notes %}
+    {% if book.references_notes|clean_value %}
         <dt class="col-sm-4">References notes</dt>
-        <dd class="col-sm-8">{{ book.references_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.references_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.secondary_sources %}
+    {% if book.secondary_sources|clean_value %}
         <dt class="col-sm-4">Secondary sources</dt>
-        <dd class="col-sm-8">{{ book.secondary_sources|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.secondary_sources|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/subscription.html
+++ b/haskala/templates/books/_sections/subscription.html
@@ -1,62 +1,63 @@
+{% load value_filters %}
 <dl class="row mb-0">
-    {% if book.subscribers %}
+    {% if book.subscribers|clean_value %}
         <dt class="col-sm-4">Subscribers</dt>
-        <dd class="col-sm-8">{{ book.subscribers|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.subscribers|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.subscribers_notes %}
+    {% if book.subscribers_notes|clean_value %}
         <dt class="col-sm-4">Subscribers notes</dt>
-        <dd class="col-sm-8">{{ book.subscribers_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.subscribers_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.subscription_appeal %}
+    {% if book.subscription_appeal|clean_value %}
         <dt class="col-sm-4">Subscription appeal</dt>
-        <dd class="col-sm-8">{{ book.subscription_appeal|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.subscription_appeal|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.subscription_appeal_notes %}
+    {% if book.subscription_appeal_notes|clean_value %}
         <dt class="col-sm-4">Subscription appeal notes</dt>
-        <dd class="col-sm-8">{{ book.subscription_appeal_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.subscription_appeal_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.recommendations %}
+    {% if book.recommendations|clean_value %}
         <dt class="col-sm-4">Recommendations</dt>
-        <dd class="col-sm-8">{{ book.recommendations|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.recommendations|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.recommendations_notes %}
+    {% if book.recommendations_notes|clean_value %}
         <dt class="col-sm-4">Recommendation notes</dt>
-        <dd class="col-sm-8">{{ book.recommendations_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.recommendations_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.price %}
+    {% if book.price|clean_value %}
         <dt class="col-sm-4">Price</dt>
-        <dd class="col-sm-8">{{ book.price }}</dd>
+        <dd class="col-sm-8">{{ book.price|clean_value }}</dd>
     {% endif %}
-    {% if book.sellers %}
+    {% if book.sellers|clean_value %}
         <dt class="col-sm-4">Sellers</dt>
-        <dd class="col-sm-8">{{ book.sellers|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.sellers|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.sellers_notes %}
+    {% if book.sellers_notes|clean_value %}
         <dt class="col-sm-4">Seller notes</dt>
-        <dd class="col-sm-8">{{ book.sellers_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.sellers_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.thanks %}
+    {% if book.thanks|clean_value %}
         <dt class="col-sm-4">Thanks</dt>
-        <dd class="col-sm-8">{{ book.thanks|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.thanks|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.thanks_notes %}
+    {% if book.thanks_notes|clean_value %}
         <dt class="col-sm-4">Thanks notes</dt>
-        <dd class="col-sm-8">{{ book.thanks_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.thanks_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.contacts_official_agents %}
+    {% if book.contacts_official_agents|clean_value %}
         <dt class="col-sm-4">Official agents</dt>
-        <dd class="col-sm-8">{{ book.contacts_official_agents|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.contacts_official_agents|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.contacts_other_people %}
+    {% if book.contacts_other_people|clean_value %}
         <dt class="col-sm-4">Other contacts</dt>
-        <dd class="col-sm-8">{{ book.contacts_other_people|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.contacts_other_people|clean_value|linebreaksbr }}</dd>
     {% endif %}
-    {% if book.personal_address %}
+    {% if book.personal_address|clean_value %}
         <dt class="col-sm-4">Personal address</dt>
-        <dd class="col-sm-8">{{ book.personal_address }}</dd>
+        <dd class="col-sm-8">{{ book.personal_address|clean_value }}</dd>
     {% endif %}
-    {% if book.personal_address_notes %}
+    {% if book.personal_address_notes|clean_value %}
         <dt class="col-sm-4">Personal address notes</dt>
-        <dd class="col-sm-8">{{ book.personal_address_notes|linebreaksbr }}</dd>
+        <dd class="col-sm-8">{{ book.personal_address_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/translations.html
+++ b/haskala/templates/books/_sections/translations.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 {% if book.translations.all %}
     <h3 class="h6 mt-3">Known translations</h3>
     <ul class="list-unstyled mb-3">
@@ -19,20 +20,20 @@
 {% endif %}
 
 <dl class="row mb-0">
-    {% if book.translation_type %}
+    {% if book.translation_type|clean_value %}
         <dt class="col-sm-4">Translation type</dt>
         <dd class="col-sm-8">{{ book.translation_type.name }}</dd>
     {% endif %}
-    {% if book.translation_notes %}
+    {% if book.translation_notes|clean_value %}
         <dt class="col-sm-4">Translation notes</dt>
-        <dd class="col-sm-8">{{ book.translation_notes }}</dd>
+        <dd class="col-sm-8">{{ book.translation_notes|clean_value }}</dd>
     {% endif %}
-    {% if book.presented_as_translation_refe %}
+    {% if book.presented_as_translation_refe|clean_value %}
         <dt class="col-sm-4">Presented as translation (reference)</dt>
-        <dd class="col-sm-8">{{ book.presented_as_translation_refe }}</dd>
+        <dd class="col-sm-8">{{ book.presented_as_translation_refe|clean_value }}</dd>
     {% endif %}
-    {% if book.presented_as_translatio_notes %}
+    {% if book.presented_as_translatio_notes|clean_value %}
         <dt class="col-sm-4">Presented as translation (notes)</dt>
-        <dd class="col-sm-8">{{ book.presented_as_translatio_notes }}</dd>
+        <dd class="col-sm-8">{{ book.presented_as_translatio_notes|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/persons/_sections/biographical.html
+++ b/haskala/templates/persons/_sections/biographical.html
@@ -1,9 +1,10 @@
+{% load value_filters %}
 <dl class="row mb-0">
-    {% if person.date_of_birth %}
+    {% if person.date_of_birth|clean_value %}
         <dt class="col-sm-4">Date of birth</dt>
-        <dd class="col-sm-8">{{ person.date_of_birth }}</dd>
+        <dd class="col-sm-8">{{ person.date_of_birth|clean_value }}</dd>
     {% endif %}
-    {% if person.place_of_birth %}
+    {% if person.place_of_birth|clean_value %}
         <dt class="col-sm-4">Place of birth</dt>
         <dd class="col-sm-8">
             <a href="{% url 'place-detail' person.place_of_birth.slug %}">
@@ -11,11 +12,11 @@
             </a>
         </dd>
     {% endif %}
-    {% if person.date_of_death %}
+    {% if person.date_of_death|clean_value %}
         <dt class="col-sm-4">Date of death</dt>
-        <dd class="col-sm-8">{{ person.date_of_death }}</dd>
+        <dd class="col-sm-8">{{ person.date_of_death|clean_value }}</dd>
     {% endif %}
-    {% if person.place_of_death %}
+    {% if person.place_of_death|clean_value %}
         <dt class="col-sm-4">Place of death</dt>
         <dd class="col-sm-8">
             <a href="{% url 'place-detail' person.place_of_death.slug %}">

--- a/haskala/templates/persons/_sections/identifiers.html
+++ b/haskala/templates/persons/_sections/identifiers.html
@@ -1,17 +1,18 @@
+{% load value_filters %}
 <dl class="row mb-0">
-    {% if person.viaf_id %}
+    {% if person.viaf_id|clean_value %}
         <dt class="col-sm-4">VIAF</dt>
         <dd class="col-sm-8">
-            <a href="https://viaf.org/viaf/{{ person.viaf_id }}/" target="_blank" rel="noopener">
-                {{ person.viaf_id }}
+            <a href="https://viaf.org/viaf/{{ person.viaf_id|clean_value }}/" target="_blank" rel="noopener">
+                {{ person.viaf_id|clean_value }}
             </a>
         </dd>
     {% endif %}
-    {% if person.gnd_id %}
+    {% if person.gnd_id|clean_value %}
         <dt class="col-sm-4">GND</dt>
         <dd class="col-sm-8">
-            <a href="https://d-nb.info/gnd/{{ person.gnd_id }}" target="_blank" rel="noopener">
-                {{ person.gnd_id }}
+            <a href="https://d-nb.info/gnd/{{ person.gnd_id|clean_value }}" target="_blank" rel="noopener">
+                {{ person.gnd_id|clean_value }}
             </a>
         </dd>
     {% endif %}

--- a/haskala/templates/persons/_sections/identity.html
+++ b/haskala/templates/persons/_sections/identity.html
@@ -1,23 +1,24 @@
+{% load value_filters %}
 <dl class="row mb-0">
-    {% if person.pref_label %}
+    {% if person.pref_label|clean_value %}
         <dt class="col-sm-4">Preferred label</dt>
-        <dd class="col-sm-8">{{ person.pref_label }}</dd>
+        <dd class="col-sm-8">{{ person.pref_label|clean_value }}</dd>
     {% endif %}
-    {% if person.german_name %}
+    {% if person.german_name|clean_value %}
         <dt class="col-sm-4">German name</dt>
-        <dd class="col-sm-8">{{ person.german_name }}</dd>
+        <dd class="col-sm-8">{{ person.german_name|clean_value }}</dd>
     {% endif %}
-    {% if person.hebrew_name %}
+    {% if person.hebrew_name|clean_value %}
         <dt class="col-sm-4">Hebrew name</dt>
-        <dd class="col-sm-8" lang="he" dir="rtl">{{ person.hebrew_name }}</dd>
+        <dd class="col-sm-8" lang="he" dir="rtl">{{ person.hebrew_name|clean_value }}</dd>
     {% endif %}
-    {% if person.pseudonym %}
+    {% if person.pseudonym|clean_value %}
         <dt class="col-sm-4">Pseudonym</dt>
-        <dd class="col-sm-8">{{ person.pseudonym }}</dd>
+        <dd class="col-sm-8">{{ person.pseudonym|clean_value }}</dd>
     {% endif %}
-    {% if person.gender %}
+    {% if person.gender|clean_value %}
         <dt class="col-sm-4">Gender</dt>
-        <dd class="col-sm-8">{{ person.gender }}</dd>
+        <dd class="col-sm-8">{{ person.gender|clean_value }}</dd>
     {% endif %}
     {% if person.occupations.all %}
         <dt class="col-sm-4">Occupations</dt>

--- a/haskala/templates/persons/_sections/mentions.html
+++ b/haskala/templates/persons/_sections/mentions.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for m in mentions_of_person %}
         <li class="mb-2">

--- a/haskala/templates/persons/_sections/prefaces.html
+++ b/haskala/templates/persons/_sections/prefaces.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for preface in prefaces_by_person %}
         <li class="mb-2">

--- a/haskala/templates/persons/_sections/productions.html
+++ b/haskala/templates/persons/_sections/productions.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for prod in productions_by_person %}
         <li class="mb-2">

--- a/haskala/templates/persons/_sections/works.html
+++ b/haskala/templates/persons/_sections/works.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 {% for role_label, books in person_books_by_role.items %}
     <h3 class="h6 mt-3">{{ role_label }}
         <span class="text-muted small fw-normal">({{ books|length }})</span>

--- a/haskala/templates/places/_sections/books_published.html
+++ b/haskala/templates/places/_sections/books_published.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for book in books_published_here %}
         <li class="mb-1">

--- a/haskala/templates/places/_sections/editions.html
+++ b/haskala/templates/places/_sections/editions.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for ed in editions_here %}
         <li class="mb-1">

--- a/haskala/templates/places/_sections/mentions.html
+++ b/haskala/templates/places/_sections/mentions.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for m in mentions_here %}
         <li class="mb-2">

--- a/haskala/templates/places/_sections/persons_born.html
+++ b/haskala/templates/places/_sections/persons_born.html
@@ -1,11 +1,12 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for person in born_here %}
         <li class="mb-1">
             <a href="{% url 'person-detail' person.slug %}" class="link-primary">
                 {{ person }}
             </a>
-            {% if person.date_of_birth %}
-                <span class="text-muted small">&middot; &#42; {{ person.date_of_birth }}</span>
+            {% if person.date_of_birth|clean_value %}
+                <span class="text-muted small">&middot; &#42; {{ person.date_of_birth|clean_value }}</span>
             {% endif %}
         </li>
     {% endfor %}

--- a/haskala/templates/places/_sections/persons_died.html
+++ b/haskala/templates/places/_sections/persons_died.html
@@ -1,11 +1,12 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for person in died_here %}
         <li class="mb-1">
             <a href="{% url 'person-detail' person.slug %}" class="link-primary">
                 {{ person }}
             </a>
-            {% if person.date_of_death %}
-                <span class="text-muted small">&middot; &#8224; {{ person.date_of_death }}</span>
+            {% if person.date_of_death|clean_value %}
+                <span class="text-muted small">&middot; &#8224; {{ person.date_of_death|clean_value }}</span>
             {% endif %}
         </li>
     {% endfor %}

--- a/haskala/templates/places/_sections/translations.html
+++ b/haskala/templates/places/_sections/translations.html
@@ -1,3 +1,4 @@
+{% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for tr in translations_here %}
         <li class="mb-1">

--- a/home/book_detail.py
+++ b/home/book_detail.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 from .models import Book
+from .templatetags.value_filters import clean_value
 
 
 @dataclass(frozen=True)
@@ -20,7 +21,14 @@ class Section:
 
 
 def _any(*values) -> bool:
-    return any(bool(v) for v in values)
+    """True when at least one value has meaningful content.
+
+    Wraps clean_value() so legacy Drupal flags like ``"0.0"`` or
+    ``"0"`` count as "no data" — without this, every Book would
+    advertise its Subscription / Dedications / Printers section
+    regardless of whether real text lives behind those flags.
+    """
+    return any(bool(clean_value(v)) for v in values)
 
 
 def _identity_has_data(b: Book) -> bool:

--- a/home/person_detail.py
+++ b/home/person_detail.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 from .models import Person
+from .templatetags.value_filters import clean_value
 
 
 @dataclass(frozen=True)
@@ -19,7 +20,7 @@ class Section:
 
 
 def _any(*values) -> bool:
-    return any(bool(v) for v in values)
+    return any(bool(clean_value(v)) for v in values)
 
 
 def _identity_has_data(p: Person) -> bool:

--- a/home/templatetags/value_filters.py
+++ b/home/templatetags/value_filters.py
@@ -1,0 +1,80 @@
+"""
+Template + Python helpers for cleaning legacy Drupal-6 field values.
+
+The original importer stored every yes/no flag as a literal string
+``"0.0"`` / ``"1.0"`` and every integer count as ``"0.0"`` / ``"1.0"``
+/ ``"2.0"`` etc. That noise leaked into the detail templates as
+``Subscribers 0.0`` / ``Subscription appeal 0.0``, which reads as
+"the value is zero" when it really means "no value".
+
+``clean_value`` collapses every "false-y but truthy in Python" shape
+to the empty string and strips trailing ``.0`` from whole-number
+floats so ``"1.0"`` renders as ``1``. Used both in
+:mod:`home.book_detail` (Python-side, to drive ``visible_sections``)
+and inside templates via the registered ``|clean_value`` filter.
+"""
+from __future__ import annotations
+
+from django import template
+
+register = template.Library()
+
+
+# Values we treat as "no value" regardless of how the importer wrote
+# them. The float and int forms cover any future code that hands the
+# filter a real number.
+_ZEROISH = {"", "0", "0.0", "0.00", "0.000", 0, 0.0, False, None}
+
+
+def clean_value(value):
+    """
+    Normalise *value* for both truth-tests and display:
+
+    - empty / zero-ish (``"0.0"``, ``"0"``, ``0``, ``False``, ``None``)
+      becomes the empty string;
+    - whole-number floats (``1.0``, ``12.0``, or their string forms)
+      lose the decimal tail (``"1"``, ``"12"``);
+    - real fractional values keep their decimal point (``"3.5"``);
+    - any other value passes through unchanged so the filter is safe
+      to apply to plain text, model objects, dates, etc.
+    """
+    if isinstance(value, bool):
+        return "" if not value else value
+    if value in _ZEROISH:
+        return ""
+
+    if isinstance(value, float):
+        return str(int(value)) if value.is_integer() else str(value)
+
+    if isinstance(value, int):
+        return str(value)
+
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped in _ZEROISH:
+            return ""
+        try:
+            as_float = float(stripped)
+        except ValueError:
+            return stripped
+        if as_float == 0:
+            return ""
+        if as_float.is_integer():
+            return str(int(as_float))
+        # Keep the user-typed form so 3.50 doesn't become 3.5 just
+        # because float parsing normalised it. Only if the original
+        # had a numeric .0 tail and a leading integer we replace it.
+        return stripped
+
+    return value
+
+
+@register.filter
+def clean_value_filter(value):
+    """Template-side wrapper. Name kept short via the alias below."""
+    return clean_value(value)
+
+
+# Register under the short ``clean_value`` name as well — that's the
+# form the templates actually use.
+register.filter("clean_value", clean_value)


### PR DESCRIPTION
PR-A of the design polish round. Seven items bundled because they all touch the visual layer.

**Headline:** the "Subscribers 0.0 / Subscription appeal 0.0 / Thanks 0.0 / Personal address 0.0" noise from the legacy Drupal import disappears from every detail page; a Book whose stored value is the legacy flag `"1.0"` now renders as `1`; sections whose only fields hold `"0.0"` collapse completely (heading + TOC entry gone).

## What

- **Palette swap** — new curated swatches, headings render in #0D0D0D for the "kräftiger" feel.
- **Font** — base 1rem (16px) replaces legacy `font-size: small` (~13px).
- **Layout** — wrapper max-width 950 → 1280 px; legal text column lands at ~820 px (was ~608); `.wrapper--narrow` modifier reserved for future long-form pages.
- **Detail headers** — `__actions` row centers + has top gap; badges get padding, dark fill with white text, brand blue on hover. Hebrew alt-title stays inside the header block (rtl + isolate).
- **person-chip** — padding bumped with `!important` against Bootstrap's badge cascade.
- **.badge.text-bg-secondary** — text forced white.
- **value_filters.clean_value** — Python + template filter for the Drupal legacy noise. 28 section templates (books/persons/places) load it. `_any()` in book_detail.py + person_detail.py uses it too so sections vanish when their fields are all zeroish.

## Test plan
- [x] manage.py test 42/42
- [x] flake8 clean
- [x] Every public route returns 200
- [x] `/books/abhandlung-von-der-freiheit-des-menschen/` no longer shows the Subscribers/Subscription/Thanks/Personal address noise
- [x] `/books/gebete-der-hochdeutschen-und-polnischen-juden/` renders `subscribers = "1.0"` as a clean `<dd>1</dd>`