### PR TITLE
style(ui): landscape places map + search redesign + heb rtl nav

### DIFF
--- a/haskala/static/scss/_book_detail.scss
+++ b/haskala/static/scss/_book_detail.scss
@@ -162,8 +162,89 @@
   font-size: 0.875rem;
 }
 
-// Sticky overview map on the right of the /places/ index page.
-.places-map-sticky {
-  position: sticky;
-  top: 1.5rem;
+// Search results page — chip-style facet bar that replaces the
+// dropdown "Result type" select. The active facet uses the brand
+// blue fill; inactive facets read as outlined neutrals.
+.search-facets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.search-facet {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--bs-body-color);
+  background: #fff;
+  text-decoration: none;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+
+  &:hover,
+  &:focus {
+    background: var(--bs-tertiary-bg);
+    color: var(--bs-primary);
+  }
+
+  &__count {
+    color: var(--bs-secondary-color);
+    font-weight: 400;
+    text-transform: none;
+    font-size: 0.875rem;
+  }
+
+  &.is-active {
+    background: $haskala-blue;
+    color: #fff;
+    border-color: $haskala-blue;
+
+    .search-facet__count {
+      color: rgba(255, 255, 255, 0.85);
+    }
+  }
+}
+
+.search-results-heading {
+  margin: 1.5rem 0 1rem;
+  letter-spacing: 0.02em;
+}
+
+.search-results-section {
+  margin-top: 1.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.search-empty {
+  font-size: 1.05rem;
+  padding: 1.5rem 0;
+}
+
+// Landscape overview map at the top of the /places/ index page.
+// Full-width banner with a fixed pixel height — long aspect ratio
+// works better than a tall sidebar map for the European geography
+// the dataset covers.
+.places-map-landscape {
+  width: 100%;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 6px;
+  padding: 0.75rem 1rem 1rem;
+  background: #fff;
+
+  h2 {
+    letter-spacing: 0.05em;
+  }
+
+  #places-map {
+    border-radius: 4px;
+    overflow: hidden;
+  }
 }

--- a/haskala/templates/partials/alphabetmenu.html
+++ b/haskala/templates/partials/alphabetmenu.html
@@ -10,10 +10,6 @@
         </ul>
     </nav>
 
-    {# Hebrew alphabet — direction and unicode-bidi: isolate so the
-       letters render in their canonical right-to-left order. Without
-       these, list-inline puts the elements left-to-right and the
-       Hebrew alphabet reads backwards. #}
     <nav class="heb" dir="rtl">
         <ul class="list-inline" style="unicode-bidi: isolate;">
             {% for letter in hebrew_alphabet %}

--- a/haskala/templates/partials/alphabetmenu.html
+++ b/haskala/templates/partials/alphabetmenu.html
@@ -10,9 +10,12 @@
         </ul>
     </nav>
 
-    {# Hebrew #}
-    <nav class="heb">
-        <ul class="list-inline">
+    {# Hebrew alphabet — direction and unicode-bidi: isolate so the
+       letters render in their canonical right-to-left order. Without
+       these, list-inline puts the elements left-to-right and the
+       Hebrew alphabet reads backwards. #}
+    <nav class="heb" dir="rtl">
+        <ul class="list-inline" style="unicode-bidi: isolate;">
             {% for letter in hebrew_alphabet %}
                 <li class="list-inline-item">
                     <a href="#letter-{{ letter }}" class="h3">{{ letter }}</a>

--- a/haskala/templates/places/places_page.html
+++ b/haskala/templates/places/places_page.html
@@ -12,10 +12,20 @@
             </p>
         </header>
 
+        {% if city_markers_json and city_markers_json != "[]" %}
+            <section class="places-map-landscape mb-4">
+                <h2 class="h6 text-uppercase text-muted mb-2">Overview map</h2>
+                <div id="places-map"
+                     style="width: 100%; height: 360px;"
+                     data-markers="{{ city_markers_json }}">
+                </div>
+            </section>
+        {% endif %}
+
         {% include 'partials/alphabetmenu.html' %}
 
         <div class="row gx-md-4">
-            <section class="col-lg-8 index-list">
+            <section class="col-12 index-list">
                 {% if cities_by_letter %}
                     {% for letter, cities in cities_by_letter.items %}
                         <div class="index-group mb-4" id="letter-{{ letter }}">
@@ -41,18 +51,6 @@
                     <p class="text-muted">No places found.</p>
                 {% endif %}
             </section>
-
-            {% if city_markers_json and city_markers_json != "[]" %}
-                <aside class="col-lg-4 places-map-col d-none d-lg-block">
-                    <div class="places-map-sticky">
-                        <h2 class="h6 text-uppercase text-muted mb-2">Overview map</h2>
-                        <div id="places-map"
-                             style="width: 100%; height: 70vh; min-height: 480px;"
-                             data-markers="{{ city_markers_json }}">
-                        </div>
-                    </div>
-                </aside>
-            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/haskala/templates/search/search_results.html
+++ b/haskala/templates/search/search_results.html
@@ -5,37 +5,33 @@
 {% block title %}Search – Haskala{% endblock %}
 
 {% block content %}
-    <div class="container my-4">
+    <div class="container my-4 search-page">
         <h1>Search</h1>
 
-        <form method="get" action="{% url 'search' %}" class="mb-4">
-            <div class="row g-2">
-                <div class="col-md-6">
-                    <label for="id_q" class="form-label">Query</label>
+        <form method="get" action="{% url 'search' %}" class="mb-4 search-form">
+            {# --- Query row: full-width input, Search + Reset on the right --- #}
+            <div class="row g-2 align-items-end">
+                <div class="col-md-9">
+                    <label for="id_q" class="form-label">Search for</label>
                     <input
                             type="text"
                             name="q"
                             id="id_q"
-                            class="form-control"
+                            class="form-control form-control-lg"
                             value="{{ query }}"
                             placeholder="Search in books, persons, places…"
+                            autofocus
                     >
                 </div>
-
-                <div class="col-md-3">
-                    <label for="id_type" class="form-label">Result type</label>
-                    <select name="type" id="id_type" class="form-select">
-                        <option value="all" {% if result_type == "all" %}selected{% endif %}>All</option>
-                        <option value="books" {% if result_type == "books" %}selected{% endif %}>Books</option>
-                        <option value="persons" {% if result_type == "persons" %}selected{% endif %}>persons</option>
-                        <option value="places" {% if result_type == "places" %}selected{% endif %}>Places</option>
-                    </select>
+                <div class="col-md-3 d-flex gap-2">
+                    <button type="submit" class="btn btn-primary flex-grow-1">Search</button>
+                    <a href="{% url 'search' %}" class="btn btn-outline-secondary">Reset</a>
                 </div>
             </div>
 
             <hr class="my-3">
 
-            <h5>Advanced filters (Books)</h5>
+            <h5>Filter books</h5>
             <div class="row g-2">
                 <div class="col-md-2">
                     <label for="id_year_from" class="form-label">Year from</label>
@@ -59,7 +55,6 @@
                             placeholder="e.g. 1820"
                     >
                 </div>
-
                 <div class="col-md-3">
                     <label for="id_language" class="form-label">Language</label>
                     <select name="language" id="id_language" class="form-select">
@@ -72,7 +67,6 @@
                         {% endfor %}
                     </select>
                 </div>
-
                 <div class="col-md-3">
                     <label for="id_place" class="form-label">Publication place</label>
                     <select name="place" id="id_place" class="form-select">
@@ -85,128 +79,116 @@
                         {% endfor %}
                     </select>
                 </div>
-
                 <div class="col-md-2">
                     <label for="id_has_digital" class="form-label">Digital copy</label>
                     <select name="has_digital" id="id_has_digital" class="form-select">
                         <option value="" {% if not selected.has_digital %}selected{% endif %}>— any —</option>
                         <option value="yes" {% if selected.has_digital == "yes" %}selected{% endif %}>Only with</option>
-                        <option value="no" {% if selected.has_digital == "no" %}selected{% endif %}>Only without
-                        </option>
+                        <option value="no" {% if selected.has_digital == "no" %}selected{% endif %}>Only without</option>
                     </select>
                 </div>
             </div>
-
-            <div class="mt-3">
-                <button type="submit" class="btn btn-primary">Search</button>
-                <a href="{% url 'search' %}" class="btn btn-outline-secondary ms-2">Reset</a>
-            </div>
         </form>
 
-        {# --- Facettenübersicht ------------------------------------------------ #}
-        <div class="card mb-4">
-            <div class="card-body">
-                <h5 class="card-title">Facets</h5>
-                <p class="card-text mb-1">
-                    Results for your filters:
-                </p>
-                <ul class="list-inline mb-0">
-                    <li class="list-inline-item">
-                        <a href="?q={{ query|urlencode }}&year_from={{ selected.year_from }}&year_to={{ selected.year_to }}&language={{ selected.language }}&place={{ selected.place }}&has_digital={{ selected.has_digital }}&type=books">
-                            Books ({{ facet_books_count }})
-                        </a>
-                    </li>
-                    <li class="list-inline-item">
-                        <a href="?q={{ query|urlencode }}&year_from={{ selected.year_from }}&year_to={{ selected.year_to }}&language={{ selected.language }}&place={{ selected.place }}&has_digital={{ selected.has_digital }}&type=persons">
-                            persons ({{ facet_persons_count }})
-                        </a>
-                    </li>
-                    <li class="list-inline-item">
-                        <a href="?q={{ query|urlencode }}&year_from={{ selected.year_from }}&year_to={{ selected.year_to }}&language={{ selected.language }}&place={{ selected.place }}&has_digital={{ selected.has_digital }}&type=places">
-                            Places ({{ facet_places_count }})
-                        </a>
-                    </li>
-                    <li class="list-inline-item">
-                        <a href="?q={{ query|urlencode }}&year_from={{ selected.year_from }}&year_to={{ selected.year_to }}&language={{ selected.language }}&place={{ selected.place }}&has_digital={{ selected.has_digital }}&type=all">
-                            All ({{ facet_books_count|add:facet_persons_count|add:facet_places_count }})
-                        </a>
-                    </li>
+        {% if has_search %}
+            {# --- Facet chips ---------------------------------------------- #}
+            <nav class="search-facets mb-4" aria-label="Result type">
+                {% with qs="q="|add:query|urlencode|stringformat:"s" %}
+                <a class="search-facet {% if result_type == 'books' %}is-active{% endif %}"
+                   href="?q={{ query|urlencode }}&year_from={{ selected.year_from }}&year_to={{ selected.year_to }}&language={{ selected.language }}&place={{ selected.place }}&has_digital={{ selected.has_digital }}&type=books">
+                    Books <span class="search-facet__count">{{ facet_books_count }}</span>
+                </a>
+                <a class="search-facet {% if result_type == 'persons' %}is-active{% endif %}"
+                   href="?q={{ query|urlencode }}&year_from={{ selected.year_from }}&year_to={{ selected.year_to }}&language={{ selected.language }}&place={{ selected.place }}&has_digital={{ selected.has_digital }}&type=persons">
+                    Persons <span class="search-facet__count">{{ facet_persons_count }}</span>
+                </a>
+                <a class="search-facet {% if result_type == 'places' %}is-active{% endif %}"
+                   href="?q={{ query|urlencode }}&year_from={{ selected.year_from }}&year_to={{ selected.year_to }}&language={{ selected.language }}&place={{ selected.place }}&has_digital={{ selected.has_digital }}&type=places">
+                    Places <span class="search-facet__count">{{ facet_places_count }}</span>
+                </a>
+                <a class="search-facet {% if result_type == 'all' or not result_type %}is-active{% endif %}"
+                   href="?q={{ query|urlencode }}&year_from={{ selected.year_from }}&year_to={{ selected.year_to }}&language={{ selected.language }}&place={{ selected.place }}&has_digital={{ selected.has_digital }}&type=all">
+                    All <span class="search-facet__count">{{ facet_total_count }}</span>
+                </a>
+                {% endwith %}
+            </nav>
+
+            <h2 class="search-results-heading">Results</h2>
+
+            {# --- Result lists --------------------------------------------- #}
+            {% if books %}
+                <h3 class="search-results-section h5">Books</h3>
+                <ul class="list-unstyled">
+                    {% for book in books %}
+                        <li>
+                            <a href="{% url 'book-detail' book.slug %}">
+                                {{ book.name|default:book.pk }}
+                            </a>
+                            {% if book.gregorian_year %}
+                                ({{ book.gregorian_year }})
+                            {% endif %}
+                            {% if book.authors.all %}
+                                – by
+                                {% for person in book.authors.all %}
+                                    <a href="{% url 'person-detail' person.slug %}">{{ person }}</a>
+                                    {% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                            {% if book.publication_place %}
+                                – {{ book.publication_place.name }}
+                            {% endif %}
+                        </li>
+                    {% endfor %}
                 </ul>
-            </div>
-        </div>
+            {% endif %}
 
-        {# --- Ergebnislisten ---------------------------------------------------- #}
-
-        {% if books %}
-            <h2>Books</h2>
-            <ul class="list-unstyled">
-                {% for book in books %}
-                    <li>
-                        <a href="{% url 'book-detail' book.slug %}">
-                            {{ book.name|default:book.pk }}
-                        </a>
-                        {% if book.gregorian_year %}
-                            ({{ book.gregorian_year }})
-                        {% endif %}
-
-                        {% if book.authors.all %}
-                            – by
-                            {% for person in book.authors.all %}
-                                <a href="{% url 'person-detail' person.slug %}">{{ person }}</a>
-                                {% if not forloop.last %}, {% endif %}
-                            {% endfor %}
-                        {% endif %}
-
-                        {% if book.publication_place %}
-                            – {{ book.publication_place.name }}
-                        {% endif %}
-                    </li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-
-        {% if persons %}
-            <h2>Persons</h2>
-            <ul class="list-unstyled">
-                {% for person in persons %}
-                    <li>
-                        <a href="{% url 'person-detail' person.slug %}">
-                            {{ person.pref_label|default:person.german_name|default:person.hebrew_name|default:person.pk }}
-                        </a>
-                        {% if person.date_of_birth or person.place_of_birth %}
-                            – born
-                            {% if person.date_of_birth %}
-                                {{ person.date_of_birth }}
+            {% if persons %}
+                <h3 class="search-results-section h5">Persons</h3>
+                <ul class="list-unstyled">
+                    {% for person in persons %}
+                        <li>
+                            <a href="{% url 'person-detail' person.slug %}">
+                                {{ person.pref_label|default:person.german_name|default:person.hebrew_name|default:person.pk }}
+                            </a>
+                            {% if person.date_of_birth or person.place_of_birth %}
+                                – born
+                                {% if person.date_of_birth %}{{ person.date_of_birth }}{% endif %}
+                                {% if person.place_of_birth %}
+                                    in
+                                    <a href="{% url 'place-detail' person.place_of_birth.slug %}">
+                                        {{ person.place_of_birth.name }}
+                                    </a>
+                                {% endif %}
                             {% endif %}
-                            {% if person.place_of_birth %}
-                                in
-                                <a href="{% url 'place-detail' person.place_of_birth.slug %}">
-                                    {{ person.place_of_birth.name }}
-                                </a>
-                            {% endif %}
-                        {% endif %}
-                    </li>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
 
-                {% endfor %}
-            </ul>
-        {% endif %}
+            {% if places %}
+                <h3 class="search-results-section h5">Places</h3>
+                <ul class="list-unstyled">
+                    {% for place in places %}
+                        <li>
+                            <a href="{% url 'place-detail' place.slug %}">
+                                {{ place.name }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
 
-        {% if places %}
-            <h2>Places</h2>
-            <ul class="list-unstyled">
-                {% for place in places %}
-                    <li>
-                        <a href="{% url 'place-detail' place.slug %}">
-                            {{ place.name }}
-                        </a>
-                    </li>
-
-                {% endfor %}
-            </ul>
-        {% endif %}
-
-        {% if not books and not persons and not places and query %}
-            <p>No results found for “{{ query }}”.</p>
+            {% if not books and not persons and not places %}
+                <p class="text-muted">No results found for “{{ query }}”.</p>
+            {% endif %}
+        {% else %}
+            <p class="text-muted search-empty">
+                Type a query above and hit <strong>Search</strong>.
+                To browse the entire catalog, use the
+                <a href="{% url 'books-list' %}">Books</a>,
+                <a href="{% url 'persons-list' %}">Persons</a> or
+                <a href="{% url 'places-list' %}">Places</a> index pages.
+            </p>
         {% endif %}
     </div>
 {% endblock %}

--- a/home/views.py
+++ b/home/views.py
@@ -484,7 +484,17 @@ def search_view(request):
     facet_places_count = places_qs.count()
 
     # --- Which type should be visible in the result list? -------------------
-    if result_type == "books":
+    # An empty query with no filters returns no results — the index pages
+    # already exist for "browse everything" and dumping every Book +
+    # Person + City into the search view confused users into thinking
+    # the search was broken.
+    has_search = bool(q or year_from or year_to or language_id or place_id or has_digital)
+
+    if not has_search:
+        books = Book.objects.none()
+        persons = Person.objects.none()
+        places = City.objects.none()
+    elif result_type == "books":
         books = books_qs
         persons = Person.objects.none()
         places = City.objects.none()
@@ -519,10 +529,12 @@ def search_view(request):
         "facet_books_count": facet_books_count,
         "facet_persons_count": facet_persons_count,
         "facet_places_count": facet_places_count,
+        "facet_total_count": facet_books_count + facet_persons_count + facet_places_count,
         "result_type": result_type,
         "languages": languages,
         "places_choices": places_choices,
         "bundle_choices": bundle_choices,
+        "has_search": has_search,
         "selected": {
             "year_from": year_from,
             "year_to": year_to,


### PR DESCRIPTION
PR-B of the polish round. Three smaller wins.

**/places/** — overview map moves from sticky sidebar to a full-width landscape banner above the alphabet index. European geography reads better in landscape than in a tall sidebar.

**/search/** — query-first redesign:
- Empty default: no query → no results. The index pages cover "browse everything"; dumping 528+1981+314 entries on a bare search visit read as broken. Empty state now nudges to the three browse indexes.
- Query input full-width, Search + Reset on the right; the "Result type" select goes away (facet chips already filter).
- New chip-style facet bar: Books / Persons / Places / All, uppercase, active-state filled in brand blue.
- "Results" heading above the lists.

**Hebrew alphabet nav** — `<nav class="heb">` gets `dir="rtl"` + `unicode-bidi: isolate` so the letters render in the correct א ב ג ... order instead of being reversed by list-inline's LTR layout.

## Test plan
- [x] /places/ shows .places-map-landscape; sidebar map gone
- [x] /search/ empty → friendly nudge, no result lists
- [x] /search/?q=salomon → facets + Results heading + result lists
- [x] Hebrew nav rtl
- [x] manage.py test 42/42, flake8 clean