### PR TITLE
chore(data): catalog audit + person-name cleanup + orphan-place tool

### DIFF
--- a/home/management/commands/audit_data_quality.py
+++ b/home/management/commands/audit_data_quality.py
@@ -1,0 +1,155 @@
+"""
+Catalog-level data audit. Writes three CSVs into
+``HASKALA_DUMPS_ROOT/<HASKALA_SLUG>/audit/`` and prints summary lines
+so cron can chain it into an alert.
+
+Three checks:
+
+- orphan_places.csv — City rows that no Book / Person / Edition /
+  Translation / Mention references. These leaked through the
+  Drupal-6 importer when a side table didn't get re-linked.
+- person_name_punctuation.csv — Person rows whose pref_label /
+  german_name / hebrew_name starts with ``(``, ``)``, ``"``, ``'``
+  or whitespace. Usually titles like ``(Dr.)`` that got into the
+  name field instead of into a separate title column.
+- duplicates.csv — Persons sharing the same pref_label or
+  hebrew_name; same shape for Books and Cities.
+
+The command is read-only. Use the dedicated fix commands
+(``clean_person_names``, ``mark_orphan_places_draft``) to act on
+the report.
+"""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+import re
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from home.models import (
+    Book, City, Edition, Mention, Person, Translation,
+)
+
+
+LEADING_PUNCT_RE = re.compile(r'^[(")\'\s,.;:]')
+
+
+class Command(BaseCommand):
+    help = "Audit the catalog for orphan places, name punctuation noise, duplicates."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--out-dir",
+            default=None,
+            help="Directory to write CSV reports into. Default: "
+                 "<HASKALA_DUMPS_ROOT>/<HASKALA_SLUG>/audit/",
+        )
+
+    def handle(self, *args, **options):
+        out_dir = Path(options["out_dir"] or (
+            Path(settings.HASKALA_DUMPS_ROOT) / settings.HASKALA_SLUG / "audit"
+        ))
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        orphans = self._collect_orphan_places()
+        self._write_orphan_places(out_dir / "orphan_places.csv", orphans)
+        self.stdout.write(self.style.WARNING(
+            f"orphan_places: {len(orphans)} / {City.objects.count()}"
+        ))
+
+        punct = self._collect_name_punctuation()
+        self._write_name_punctuation(out_dir / "person_name_punctuation.csv", punct)
+        self.stdout.write(self.style.WARNING(
+            f"person_name_punctuation: {len(punct)} field/value pairs"
+        ))
+
+        dups = self._collect_duplicates()
+        self._write_duplicates(out_dir / "duplicates.csv", dups)
+        self.stdout.write(self.style.WARNING(
+            f"duplicates: {sum(len(v) for v in dups.values())} keys "
+            f"across {sum(len(rows) for v in dups.values() for rows in v.values())} rows"
+        ))
+
+        self.stdout.write(self.style.SUCCESS(f"Reports written to {out_dir}"))
+
+    # ----- collectors ---------------------------------------------
+
+    def _collect_orphan_places(self):
+        orphans = []
+        for c in City.objects.all():
+            if Book.objects.filter(
+                Q(publication_place=c)
+                | Q(publication_place_other=c)
+                | Q(original_publication_place=c)
+            ).exists():
+                continue
+            if Person.objects.filter(
+                Q(place_of_birth=c) | Q(place_of_death=c)
+            ).exists():
+                continue
+            if Edition.objects.filter(city=c).exists():
+                continue
+            if Translation.objects.filter(city=c).exists():
+                continue
+            if Mention.objects.filter(mentionee_city=c).exists():
+                continue
+            orphans.append(c)
+        return orphans
+
+    def _collect_name_punctuation(self):
+        out = []
+        for p in Person.objects.all():
+            for fname in ("pref_label", "german_name", "hebrew_name"):
+                value = (getattr(p, fname, "") or "").strip()
+                if value and LEADING_PUNCT_RE.match(value):
+                    out.append((p, fname, value))
+        return out
+
+    def _collect_duplicates(self):
+        """Returns {model_name: {key: [pks…]}} for keys with len>1."""
+        result = {}
+        for model, fields in [
+            (Person, ("pref_label", "german_name", "hebrew_name")),
+            (Book, ("name",)),
+            (City, ("name",)),
+        ]:
+            per_model = {}
+            for fname in fields:
+                groups = {}
+                for o in model.objects.all():
+                    key = (getattr(o, fname, "") or "").strip().lower()
+                    if not key:
+                        continue
+                    groups.setdefault((fname, key), []).append(o.pk)
+                for k, ids in groups.items():
+                    if len(ids) > 1:
+                        per_model[k] = ids
+            result[model.__name__] = per_model
+        return result
+
+    # ----- writers ------------------------------------------------
+
+    def _write_orphan_places(self, path, orphans):
+        with path.open("w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["uuid", "name", "slug", "live"])
+            for c in orphans:
+                w.writerow([c.pk, c.name, c.slug, c.live])
+
+    def _write_name_punctuation(self, path, rows):
+        with path.open("w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["uuid", "field", "current_value"])
+            for p, fname, value in rows:
+                w.writerow([p.pk, fname, value])
+
+    def _write_duplicates(self, path, dups):
+        with path.open("w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["model", "field", "value", "uuids"])
+            for model_name, by_key in dups.items():
+                for (fname, key), ids in sorted(by_key.items()):
+                    w.writerow([model_name, fname, key, ";".join(str(i) for i in ids)])

--- a/home/management/commands/clean_person_names.py
+++ b/home/management/commands/clean_person_names.py
@@ -1,0 +1,91 @@
+"""
+Strip leading punctuation and parens-wrapped titles from Person name
+fields. The Drupal-6 importer left strings like ``(Dr.) NAME`` or
+``"NAME"`` in pref_label / german_name / hebrew_name; the latter
+patterns aren't legitimate name forms and read as broken on the
+public detail page.
+
+Transforms applied per field (pref_label, german_name, hebrew_name):
+
+1. Drop one leading ``(...)`` group + the following whitespace
+   (handles ``(Dr. med.) Foo`` → ``Foo``).
+2. Strip surrounding ``"..."`` quotes (handles ``"Bar"`` → ``Bar``).
+3. Strip leading whitespace and stray punctuation
+   (``, ``  ``. `` etc.).
+4. Collapse runs of internal whitespace.
+
+The command is idempotent and prints what it would do; pass
+``--apply`` to commit the changes.
+"""
+from __future__ import annotations
+
+import re
+
+from django.core.management.base import BaseCommand
+
+from home.models import Person
+
+
+_PARENS_PREFIX = re.compile(r"^\([^)]*\)\s*")
+_QUOTE_WRAP = re.compile(r'^"(.*)"$')
+_LEADING_JUNK = re.compile(r"^[\s,.;:'\"]+")
+_MULTI_WS = re.compile(r"\s{2,}")
+
+
+def clean(value: str) -> str:
+    if not value:
+        return value
+    out = value
+    out = _PARENS_PREFIX.sub("", out)
+    m = _QUOTE_WRAP.match(out)
+    if m:
+        out = m.group(1)
+    out = _LEADING_JUNK.sub("", out)
+    out = _MULTI_WS.sub(" ", out).strip()
+    return out
+
+
+class Command(BaseCommand):
+    help = "Strip leading punctuation / parens-wrapped titles from Person names."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Commit the changes. Without it the command runs as a dry-run.",
+        )
+
+    def handle(self, *args, **options):
+        apply = options["apply"]
+        changed = []
+        for p in Person.objects.all():
+            updates = {}
+            for fname in ("pref_label", "german_name", "hebrew_name"):
+                current = getattr(p, fname, "") or ""
+                new = clean(current)
+                if new != current:
+                    updates[fname] = (current, new)
+            if updates:
+                changed.append((p, updates))
+
+        for p, updates in changed:
+            for fname, (old, new) in updates.items():
+                self.stdout.write(
+                    f"{p.pk} {fname}: {old!r} -> {new!r}"
+                )
+
+        if not apply:
+            self.stdout.write(self.style.WARNING(
+                f"DRY RUN: would update {len(changed)} Person rows. "
+                f"Re-run with --apply to commit."
+            ))
+            return
+
+        for p, updates in changed:
+            for fname, (_old, new) in updates.items():
+                setattr(p, fname, new)
+            p.save(update_fields=list(updates))
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Updated {len(changed)} Person rows."
+        ))

--- a/home/management/commands/mark_orphan_places_draft.py
+++ b/home/management/commands/mark_orphan_places_draft.py
@@ -1,0 +1,68 @@
+"""
+Mark every City with zero references as ``live=False`` so it
+disappears from the public site without losing the row. Recoverable —
+flipping the row back to ``live=True`` un-archives it.
+
+Use this after ``audit_data_quality`` has confirmed the orphan list
+matches the expected output. Dry-run by default.
+"""
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from home.models import (
+    Book, City, Edition, Mention, Person, Translation,
+)
+
+
+def is_orphan(c: City) -> bool:
+    if Book.objects.filter(
+        Q(publication_place=c)
+        | Q(publication_place_other=c)
+        | Q(original_publication_place=c)
+    ).exists():
+        return False
+    if Person.objects.filter(
+        Q(place_of_birth=c) | Q(place_of_death=c)
+    ).exists():
+        return False
+    if Edition.objects.filter(city=c).exists():
+        return False
+    if Translation.objects.filter(city=c).exists():
+        return False
+    if Mention.objects.filter(mentionee_city=c).exists():
+        return False
+    return True
+
+
+class Command(BaseCommand):
+    help = "Set live=False on every City that no other record references."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Commit the changes. Default: dry-run.",
+        )
+
+    def handle(self, *args, **options):
+        apply = options["apply"]
+        orphans = [c for c in City.objects.filter(live=True) if is_orphan(c)]
+
+        for c in orphans:
+            self.stdout.write(f"{c.pk}  {c.name!r}  -> live=False")
+
+        if not apply:
+            self.stdout.write(self.style.WARNING(
+                f"DRY RUN: would set live=False on {len(orphans)} "
+                f"orphan cities. Re-run with --apply to commit."
+            ))
+            return
+
+        for c in orphans:
+            c.live = False
+            c.save(update_fields=["live"])
+        self.stdout.write(self.style.SUCCESS(
+            f"Marked {len(orphans)} orphan cities as draft (live=False)."
+        ))


### PR DESCRIPTION
PR-C of the polish round — three management commands to investigate and act on the data-quality findings.

## Numbers on the current dataset

| Check | Count |
| ----- | ----- |
| Orphan cities (no Book/Person/Edition/Translation/Mention link) | 112 / 314 |
| Person fields with leading punctuation | 13 (12 rows) |
| Person pref_label duplicates | 80 (204 rows) |
| Person hebrew_name duplicates | 56 |
| Book.name / City.name duplicates | 0 |

## Three commands

- `audit_data_quality` — read-only, writes three CSVs into `HASKALA_DUMPS_ROOT/<slug>/audit/` (orphan_places, person_name_punctuation, duplicates).
- `clean_person_names` — strips one leading `(...)` group, surrounding `"..."` quotes, and leading punctuation. Already applied on dev: 12 Person rows updated; punctuation count now zero.
- `mark_orphan_places_draft` — sets `live=False` on every City the audit flags as orphan. Dry-run only in this PR; run with `--apply` once the CSV has been reviewed.

Duplicates are reported but not auto-merged — Person merges drag BookAuthor / place_of_birth / place_of_death links along, which is a judgment call per pair.

## Test plan
- [x] manage.py audit_data_quality writes the three CSVs
- [x] manage.py clean_person_names --apply landed 12 updates
- [x] manage.py mark_orphan_places_draft (dry-run) lists 112 cities
- [x] manage.py test 42/42, flake8 clean