### PR TITLE
style(theme): revert link colour + body-toned headings + section alignment

### DIFF
--- a/haskala/static/scss/_book_detail.scss
+++ b/haskala/static/scss/_book_detail.scss
@@ -116,14 +116,18 @@
   scroll-margin-top: 5rem; // sticky-header offset for #anchor jumps
   padding-top: 1.25rem;
   padding-bottom: 1rem;
-
-  &:not(:first-of-type) {
-    border-top: 1px solid var(--bs-border-color);
-  }
+  // Body sets `text-align: center` globally; reset to the natural
+  // start edge so dl rows read left-to-right (or right-to-left in
+  // RTL contexts) instead of stacking centered.
+  text-align: start;
 
   &__heading {
     margin-bottom: 1rem;
     color: var(--bs-emphasis-color);
+    // The body of the section sits left-aligned (text-align: start
+    // on the section block), but the H2 heading itself stays
+    // centered as a divider between sections.
+    text-align: center;
   }
 
   // Definition lists are the workhorse format on these pages.

--- a/haskala/static/scss/_variables.scss
+++ b/haskala/static/scss/_variables.scss
@@ -13,10 +13,12 @@
 //     updating the moodboard) ---
 $haskala-base:    #5e5d58;  // body text & icons (warm grey)
 $haskala-dark:    #595752;  // hover state for body text / dividers
-$haskala-black:   #0D0D0D;  // headings & high-contrast text
+$haskala-black:   #0D0D0D;  // optional high-contrast accent (kept for callers)
 $haskala-cream:   #F2F1DC;  // page wash / decorative background
 
-$haskala-blue:    #4992F2;  // primary link / brand
+// Links stay on the historical teal-blue; the moodboard cobalt
+// (#4992F2) didn't carry the same scholarly tone.
+$haskala-blue:    #1f6e94;  // primary link / brand
 $haskala-blue-2:  #5F94D9;  // secondary blue (info / muted accents)
 $haskala-cyan:    #82C0D9;  // soft accent / success-ish
 $haskala-violet:  #797FF2;  // info / facets
@@ -58,7 +60,9 @@ $font-family-base:        $font-family-sans-serif;
 $headings-font-family:    'bell_mtbold', $font-family-sans-serif;
 $headings-font-weight:    700;
 $headings-line-height:    1.15;
-$headings-color:          $haskala-black;
+// Headings track the body colour rather than near-black; the user
+// finds the latter too punchy against the warm grey of body copy.
+$headings-color:          $haskala-base;
 
 // =========================================================
 // GLOBAL COLORS (Bootstrap)


### PR DESCRIPTION
Four follow-up tweaks after PR #65 / #66 / #67 went live.

- Links: `#4992F2` (moodboard cobalt) → `#1f6e94` (historical teal-blue, scholarly tone).
- Headings: `#0D0D0D` → `#5e5d58` (body grey).
- Detail-page sections: drop the inter-section `border-top`. Padding alone separates them.
- Detail-page sections: `text-align: start` so dl rows flow in the document's natural direction instead of inheriting the global `body { text-align: center }`. The section H2 stays `text-align: center` as a divider.

## Test plan
- [x] manage.py test 42/42
- [x] /books/<slug>/ renders 200; sections are left-aligned, h2 centered
- [x] CSS confirms link colour `#1f6e94`, no `#4992f2`, no section border-top