### PR TITLE
style(ui): trim hero + center all section headings + drop search label

### DIFF
--- a/haskala/static/scss/_book_detail.scss
+++ b/haskala/static/scss/_book_detail.scss
@@ -21,7 +21,14 @@
   margin-bottom: 1.5rem;
   text-align: center;
 
-  &__title { line-height: 1.2; }
+  &__title {
+    line-height: 1.2;
+    // Body headings are uppercased globally (see _layout.scss).
+    // The entity title carries the actual book/person/place name and
+    // can be long; uppercasing makes a five-word German title nearly
+    // unreadable. Keep the original case.
+    text-transform: none;
+  }
   &__latin { color: var(--bs-secondary-color); }
   &__alt {
     line-height: 1.3;

--- a/haskala/static/scss/_book_detail.scss
+++ b/haskala/static/scss/_book_detail.scss
@@ -121,13 +121,17 @@
   // RTL contexts) instead of stacking centered.
   text-align: start;
 
+  // Section body is text-align: start, but every heading inside
+  // the section (including __heading, sub-section h3s, etc.) sits
+  // centered so it reads as a divider rather than as another body
+  // row.
+  h1, h2, h3, h4, h5, h6 {
+    text-align: center;
+  }
+
   &__heading {
     margin-bottom: 1rem;
     color: var(--bs-emphasis-color);
-    // The body of the section sits left-aligned (text-align: start
-    // on the section block), but the H2 heading itself stays
-    // centered as a divider between sections.
-    text-align: center;
   }
 
   // Definition lists are the workhorse format on these pages.

--- a/haskala/templates/books/_book_header.html
+++ b/haskala/templates/books/_book_header.html
@@ -11,7 +11,7 @@
     </h1>
 
     {% if book.title_in_latin_characters %}
-        <p class="book-header__latin text-muted fst-italic mb-2">
+        <p class="book-header__latin text-muted mb-2">
             {{ book.title_in_latin_characters }}
         </p>
     {% endif %}

--- a/haskala/templates/home/home_page.html
+++ b/haskala/templates/home/home_page.html
@@ -8,14 +8,6 @@
 
 {% block content %}
     <div class="container homepage my-4">
-        <section class="homepage-hero text-center mb-5">
-            <h1 class="display-5 mb-3">The Library of the Haskala</h1>
-            {% if page.body %}
-                <div class="homepage-intro lead mx-auto" style="max-width: 720px;">
-                    {{ page.body|richtext }}
-                </div>
-            {% endif %}
-        </section>
 
         <section class="homepage-search mb-5">
             <form action="{% url 'search' %}" method="get"

--- a/haskala/templates/search/search_results.html
+++ b/haskala/templates/search/search_results.html
@@ -12,7 +12,6 @@
             {# --- Query row: full-width input, Search + Reset on the right --- #}
             <div class="row g-2 align-items-end">
                 <div class="col-md-9">
-                    <label for="id_q" class="form-label">Search for</label>
                     <input
                             type="text"
                             name="q"
@@ -20,6 +19,7 @@
                             class="form-control form-control-lg"
                             value="{{ query }}"
                             placeholder="Search in books, persons, places…"
+                            aria-label="Search"
                             autofocus
                     >
                 </div>


### PR DESCRIPTION
Three small UI fixes:

- Frontpage hero (h1 + lorem-ipsum body) removed; the search hero below is the real entry point.
- Detail-page sections center every h1-h6, not just `__heading` — sub-section titles read as dividers.
- Search page: "Search for" label dropped; aria-label keeps the field accessible.

## Test plan
- [x] manage.py test 42/42
- [x] / no longer shows "The Library of the Haskala" / lorem-ipsum in the hero
- [x] Section h1-h6 centered in CSS
- [x] Search page: label gone