### PR TITLE
style(theme): header actions as badges + headings #5e5d58 + index alignment

### DIFF
--- a/haskala/static/scss/_book_detail.scss
+++ b/haskala/static/scss/_book_detail.scss
@@ -50,24 +50,23 @@
     margin-top: 1rem;
 
     // Badge-shaped action chips need their own padding because the
-    // .badge utility otherwise renders them flush — and a darker
-    // fill with light text reads better against the warm cream / white
-    // background of the header.
+    // .badge utility otherwise renders them flush. Background +
+    // text colour come from Bootstrap's .text-bg-secondary utility
+    // (which we override to use white text in PR #65); no need to
+    // re-set the colour here.
     .badge,
     a.badge,
+    button.badge,
     a.btn.badge,
     .book-header__action {
       padding: 0.5rem 0.85rem;
       font-size: 0.875rem;
       line-height: 1.2;
-      color: #fff;
-      background-color: $haskala-black;
-      border-color: $haskala-black;
+      border: 0;
 
       &:hover,
       &:focus {
-        background-color: $haskala-blue;
-        border-color: $haskala-blue;
+        background-color: rgba(var(--bs-secondary-rgb), 0.85);
         color: #fff;
       }
     }
@@ -241,6 +240,21 @@
 .search-empty {
   font-size: 1.05rem;
   padding: 1.5rem 0;
+}
+
+// Index pages (books / persons / places / digital-books). The
+// global body { text-align: center } would otherwise center every
+// list item under the alphabet heading; we want the alphabetic list
+// to read flush-left like a real catalog. The h2 letter heading
+// keeps its centered look from the section h1-h6 rule above by
+// virtue of having its own __heading rule.
+.index-list,
+.index-group {
+  text-align: start;
+}
+
+.index-group__heading {
+  text-align: center;
 }
 
 // Landscape overview map at the top of the /places/ index page.

--- a/haskala/static/scss/_layout.scss
+++ b/haskala/static/scss/_layout.scss
@@ -21,12 +21,13 @@ body {
   position: relative; // kommt aus overrides.css
 }
 
-// Überschriften: uppercase + Haskala-Headline-Font
+// Überschriften: uppercase + Haskala-Headline-Font + body grey
 h1, h2, h3, h4, h5, h6 {
   text-transform: uppercase;
   font-family: $headings-font-family;
   font-weight: $headings-font-weight;
   line-height: $headings-line-height;
+  color: $haskala-base;
 }
 
 // Links – nutzen nur noch die Bootstrap-Variablen

--- a/haskala/static/scss/_pages.scss
+++ b/haskala/static/scss/_pages.scss
@@ -18,7 +18,7 @@
     margin-bottom: 51px;
 
     h3 {
-      color: $haskala-blue;
+      color: $haskala-base;
       font-family: $headings-font-family;
       font-weight: 700;
       margin: 0 4px 0 0;

--- a/haskala/templates/books/_book_header.html
+++ b/haskala/templates/books/_book_header.html
@@ -31,19 +31,19 @@
     <div class="book-header__actions">
         {% if book.digital_book_url %}
             <a href="{{ book.digital_book_url }}" target="_blank" rel="noopener"
-               class="btn btn-sm btn-outline-info">
+               class="btn btn-sm btn-secondary">
                 <i class="bi bi-book"></i> View digital copy
             </a>
         {% endif %}
-        <button type="button" class="btn btn-sm btn-outline-secondary"
+        <button type="button" class="badge text-bg-secondary"
                 data-bs-toggle="modal" data-bs-target="#book-cite-modal">
             <i class="bi bi-quote"></i> Cite
         </button>
-        <button type="button" class="btn btn-sm btn-outline-secondary"
+        <button type="button" class="badge text-bg-secondary"
                 data-bs-toggle="modal" data-bs-target="#book-export-modal">
             <i class="bi bi-file-earmark-arrow-down"></i> Export
         </button>
-        <button type="button" class="btn btn-sm btn-outline-secondary"
+        <button type="button" class="badge text-bg-secondary"
                 data-permalink="{{ request.build_absolute_uri }}"
                 aria-label="Copy permalink">
             <i class="bi bi-link-45deg"></i> Permalink

--- a/haskala/templates/books/books_page.html
+++ b/haskala/templates/books/books_page.html
@@ -18,7 +18,7 @@
             {% if books_by_letter %}
                 {% for letter, books in books_by_letter.items %}
                     <div class="index-group mb-4" id="letter-{{ letter }}">
-                        <h2 class="index-group__heading h4 border-bottom pb-1">{{ letter }}</h2>
+                        <h2 class="index-group__heading h4 pb-1">{{ letter }}</h2>
                         <ul class="list-unstyled mb-0">
                             {% for book in books %}
                                 <li class="mb-1">

--- a/haskala/templates/digital-books/digital_books_page.html
+++ b/haskala/templates/digital-books/digital_books_page.html
@@ -18,7 +18,7 @@
             {% if books_by_letter %}
                 {% for letter, books in books_by_letter.items %}
                     <div class="index-group mb-4" id="letter-{{ letter }}">
-                        <h2 class="index-group__heading h4 border-bottom pb-1">{{ letter }}</h2>
+                        <h2 class="index-group__heading h4 pb-1">{{ letter }}</h2>
                         <ul class="list-unstyled mb-0">
                             {% for book in books %}
                                 <li class="mb-1">
@@ -32,7 +32,7 @@
                                     {% endif %}
                                     {% if book.digital_book_url %}
                                         <a href="{{ book.digital_book_url }}" target="_blank" rel="noopener"
-                                           class="link-secondary small ms-2">
+                                           class="badge text-bg-secondary ms-2">
                                             <i class="bi bi-box-arrow-up-right"></i> Open digital copy
                                         </a>
                                     {% endif %}

--- a/haskala/templates/occupations/occupation_detail_page.html
+++ b/haskala/templates/occupations/occupation_detail_page.html
@@ -23,7 +23,7 @@
             </p>
 
             <div class="occupation-header__actions">
-                <button type="button" class="btn btn-sm btn-outline-secondary"
+                <button type="button" class="badge text-bg-secondary"
                         data-permalink="{{ request.build_absolute_uri }}"
                         aria-label="Copy permalink">
                     <i class="bi bi-link-45deg"></i> Permalink

--- a/haskala/templates/persons/_person_header.html
+++ b/haskala/templates/persons/_person_header.html
@@ -61,21 +61,21 @@
     <div class="person-header__actions">
         {% if person.viaf_id %}
             <a href="https://viaf.org/viaf/{{ person.viaf_id }}/" target="_blank" rel="noopener"
-               class="btn btn-sm btn-outline-info">
+               class="badge text-bg-secondary">
                 <i class="bi bi-box-arrow-up-right"></i> VIAF {{ person.viaf_id }}
             </a>
         {% endif %}
         {% if person.gnd_id %}
             <a href="https://d-nb.info/gnd/{{ person.gnd_id }}" target="_blank" rel="noopener"
-               class="btn btn-sm btn-outline-info">
+               class="badge text-bg-secondary">
                 <i class="bi bi-box-arrow-up-right"></i> GND {{ person.gnd_id }}
             </a>
         {% endif %}
-        <button type="button" class="btn btn-sm btn-outline-secondary"
+        <button type="button" class="badge text-bg-secondary"
                 data-bs-toggle="modal" data-bs-target="#person-export-modal">
             <i class="bi bi-file-earmark-arrow-down"></i> Export
         </button>
-        <button type="button" class="btn btn-sm btn-outline-secondary"
+        <button type="button" class="badge text-bg-secondary"
                 data-permalink="{{ request.build_absolute_uri }}"
                 aria-label="Copy permalink">
             <i class="bi bi-link-45deg"></i> Permalink

--- a/haskala/templates/persons/persons_page.html
+++ b/haskala/templates/persons/persons_page.html
@@ -18,7 +18,7 @@
             {% if persons_by_letter %}
                 {% for letter, persons in persons_by_letter.items %}
                     <div class="index-group mb-4" id="letter-{{ letter }}">
-                        <h2 class="index-group__heading h4 border-bottom pb-1">{{ letter }}</h2>
+                        <h2 class="index-group__heading h4 pb-1">{{ letter }}</h2>
                         <ul class="list-unstyled mb-0">
                             {% for person in persons %}
                                 <li class="mb-1">

--- a/haskala/templates/places/_place_header.html
+++ b/haskala/templates/places/_place_header.html
@@ -28,11 +28,11 @@
     {% endif %}
 
     <div class="place-header__actions">
-        <button type="button" class="btn btn-sm btn-outline-secondary"
+        <button type="button" class="badge text-bg-secondary"
                 data-bs-toggle="modal" data-bs-target="#place-export-modal">
             <i class="bi bi-file-earmark-arrow-down"></i> Export
         </button>
-        <button type="button" class="btn btn-sm btn-outline-secondary"
+        <button type="button" class="badge text-bg-secondary"
                 data-permalink="{{ request.build_absolute_uri }}"
                 aria-label="Copy permalink">
             <i class="bi bi-link-45deg"></i> Permalink

--- a/haskala/templates/places/places_page.html
+++ b/haskala/templates/places/places_page.html
@@ -29,7 +29,7 @@
                 {% if cities_by_letter %}
                     {% for letter, cities in cities_by_letter.items %}
                         <div class="index-group mb-4" id="letter-{{ letter }}">
-                            <h2 class="index-group__heading h4 border-bottom pb-1">{{ letter }}</h2>
+                            <h2 class="index-group__heading h4 pb-1">{{ letter }}</h2>
                             <ul class="list-unstyled mb-0">
                                 {% for city in cities %}
                                     <li class="mb-1">

--- a/haskala/templates/publishers/publisher_detail_page.html
+++ b/haskala/templates/publishers/publisher_detail_page.html
@@ -26,7 +26,7 @@
             </p>
 
             <div class="publisher-header__actions">
-                <button type="button" class="btn btn-sm btn-outline-secondary"
+                <button type="button" class="badge text-bg-secondary"
                         data-permalink="{{ request.build_absolute_uri }}"
                         aria-label="Copy permalink">
                     <i class="bi bi-link-45deg"></i> Permalink

--- a/haskala/templates/search/search_results.html
+++ b/haskala/templates/search/search_results.html
@@ -25,7 +25,7 @@
                 </div>
                 <div class="col-md-3 d-flex gap-2">
                     <button type="submit" class="btn btn-primary flex-grow-1">Search</button>
-                    <a href="{% url 'search' %}" class="btn btn-outline-secondary">Reset</a>
+                    <a href="{% url 'search' %}" class="btn btn-secondary">Reset</a>
                 </div>
             </div>
 

--- a/haskala/templates/series/series_detail_page.html
+++ b/haskala/templates/series/series_detail_page.html
@@ -23,7 +23,7 @@
             </p>
 
             <div class="series-header__actions">
-                <button type="button" class="btn btn-sm btn-outline-secondary"
+                <button type="button" class="badge text-bg-secondary"
                         data-permalink="{{ request.build_absolute_uri }}"
                         aria-label="Copy permalink">
                     <i class="bi bi-link-45deg"></i> Permalink

--- a/haskala/templates/topics/topic_detail_page.html
+++ b/haskala/templates/topics/topic_detail_page.html
@@ -23,7 +23,7 @@
             </p>
 
             <div class="topic-header__actions">
-                <button type="button" class="btn btn-sm btn-outline-secondary"
+                <button type="button" class="badge text-bg-secondary"
                         data-permalink="{{ request.build_absolute_uri }}"
                         aria-label="Copy permalink">
                     <i class="bi bi-link-45deg"></i> Permalink


### PR DESCRIPTION
Follow-up design tweaks from the live preview of PR #71.

## Header actions on detail pages
- Cite / Export / Permalink (plus VIAF / GND on Person) → `.badge.text-bg-secondary` so they share the secondary fill the user wants, with white text from the existing override.
- "View digital copy" is the only solid button (`btn-secondary`) on the Book header.

## Headings
- Global h1-h6 + tags-cloud-wrapper h3 → `#5e5d58` (no more blue h3 on the home page).

## Search
- Reset → `btn-secondary` (looks the way the outline variant did on hover).

## Index pages
- Drop the `border-bottom` from `.index-group__heading` on books / persons / places / digital-books.
- New rule: `.index-list, .index-group { text-align: start }` so list items read flush-left; the H2 letter heading stays centered.
- digital-books "Open digital copy" → `.badge.text-bg-secondary` to match the other action chips.

## Test plan
- [x] manage.py test 42/42, flake8 clean
- [x] Detail header actions: 4 badges + 1 `btn-secondary` (View digital copy)
- [x] /books/, /digital-books/ index lists are flush-left
- [x] /search/ Reset has `btn-secondary`