### PR TITLE
feat(contact): hCaptcha challenge on the /contact/ form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,12 @@ EMAIL_RELAY_TLS_LEVEL=encrypt
 DEFAULT_FROM_EMAIL=haskala@example.org
 SERVER_EMAIL=haskala@example.org
 
+# ----- hCaptcha (public /contact/ form) -----
+# Empty disables the challenge — useful for local dev. Production
+# should always set both. https://dashboard.hcaptcha.com/
+HCAPTCHA_SITE_KEY=
+HCAPTCHA_SECRET_KEY=
+
 # ----- RDF auto-push to SPARQL endpoint (optional) -----
 # Empty disables the push; export_rdf still writes its local files.
 HASKALA_SPARQL_PUSH_URL=

--- a/haskala/settings/base.py
+++ b/haskala/settings/base.py
@@ -391,6 +391,13 @@ HASKALA_SPARQL_PUSH_USER = env("HASKALA_SPARQL_PUSH_USER", default="")
 HASKALA_SPARQL_PUSH_PASSWORD = env("HASKALA_SPARQL_PUSH_PASSWORD", default="")
 HASKALA_SPARQL_PUSH_TIMEOUT = env("HASKALA_SPARQL_PUSH_TIMEOUT", default=60, cast=int)
 
+# hCaptcha keys for the public /contact/ form. Get them from
+# https://dashboard.hcaptcha.com/. Leave empty to disable the
+# challenge (e.g. on local dev where you'd otherwise need real
+# keys to submit the form).
+HCAPTCHA_SITE_KEY = env("HCAPTCHA_SITE_KEY", default="")
+HCAPTCHA_SECRET_KEY = env("HCAPTCHA_SECRET_KEY", default="")
+
 # djangordf is the JudaicaLink-internal Django/RDF bridge. We use it
 # from haskala_rdf.push() to talk SPARQL Update to Fuseki; the
 # build_data_graph() pipeline keeps producing the raw rdflib graph

--- a/haskala/templates/contact/contact_page.html
+++ b/haskala/templates/contact/contact_page.html
@@ -40,6 +40,19 @@
 
                         {{ form.as_p }}
 
+                        {% if HCAPTCHA_SITE_KEY %}
+                            {# hCaptcha challenge. Renders an iframe + a
+                               hidden h-captcha-response field that the
+                               server verifies in ContactPage.serve(). #}
+                            <div class="mb-3">
+                                <div class="h-captcha" data-sitekey="{{ HCAPTCHA_SITE_KEY }}"></div>
+                                {% if hcaptcha_error %}
+                                    <div class="text-danger small mt-2">{{ hcaptcha_error }}</div>
+                                {% endif %}
+                            </div>
+                            <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
+                        {% endif %}
+
                         <button type="submit" class="btn btn-primary">
                             Send message
                         </button>

--- a/home/models.py
+++ b/home/models.py
@@ -1506,9 +1506,26 @@ class ContactPage(AbstractEmailForm):
     def serve(self, request, *args, **kwargs):
         """
         Handle form display + submission with success/error messages.
+
+        When HCAPTCHA_SITE_KEY + HCAPTCHA_SECRET_KEY are set, the
+        h-captcha-response field is verified against hCaptcha's
+        siteverify endpoint before the form-data is processed. An
+        empty / failed verification re-renders the form with an
+        error so spam can't reach the inbox.
         """
         if request.method == "POST":
             form = self.get_form(request.POST, request.FILES)
+
+            hcaptcha_error = self._verify_hcaptcha(request)
+            if hcaptcha_error:
+                context = self.get_context(request)
+                context["form"] = form
+                context["hcaptcha_error"] = hcaptcha_error
+                return TemplateResponse(
+                    request,
+                    self.get_template(request),
+                    context,
+                )
 
             if form.is_valid():
                 try:
@@ -1568,6 +1585,50 @@ class ContactPage(AbstractEmailForm):
             self.get_template(request),
             context,
         )
+
+    def get_context(self, request, *args, **kwargs):
+        """Expose HCAPTCHA_SITE_KEY so the template can render the
+        widget. Empty string disables the widget cleanly."""
+        from django.conf import settings as dj_settings
+        ctx = super().get_context(request, *args, **kwargs)
+        ctx["HCAPTCHA_SITE_KEY"] = getattr(dj_settings, "HCAPTCHA_SITE_KEY", "") or ""
+        return ctx
+
+    def _verify_hcaptcha(self, request):
+        """Verify the h-captcha-response field against hCaptcha's
+        siteverify endpoint. Returns None on success or when the
+        feature is disabled (no secret configured), otherwise an
+        error string the template renders next to the widget."""
+        import requests
+        from django.conf import settings as dj_settings
+
+        secret = getattr(dj_settings, "HCAPTCHA_SECRET_KEY", "") or ""
+        if not secret:
+            # hCaptcha disabled; treat every submission as verified.
+            return None
+
+        token = request.POST.get("h-captcha-response", "")
+        if not token:
+            return "Please complete the captcha challenge."
+
+        try:
+            response = requests.post(
+                "https://api.hcaptcha.com/siteverify",
+                data={"secret": secret, "response": token,
+                      "remoteip": request.META.get("REMOTE_ADDR", "")},
+                timeout=10,
+            )
+            response.raise_for_status()
+        except requests.RequestException:
+            # If the verifier is unreachable we err on the safe side
+            # and reject — better a temporary "try again" than a spam
+            # leak through an outage.
+            return "Captcha verification is unavailable right now. Please try again later."
+
+        data = response.json()
+        if data.get("success"):
+            return None
+        return "Captcha verification failed. Please try again."
 
 
 class BookDetailPage(Page):


### PR DESCRIPTION
The existing `ContactPage` (Wagtail AbstractEmailForm) had no spam protection. Adds hCaptcha verification keyed on two env vars; disabled when keys are empty so dev stays testable.

## What
- `ContactPage._verify_hcaptcha()` POSTs the `h-captcha-response` token to hCaptcha's siteverify with `HCAPTCHA_SECRET_KEY` + the requester IP. Fail-closed on network errors.
- `serve()` runs verify before `form.is_valid()`; rejection re-renders the form with an inline error.
- Template lazy-loads the hCaptcha JS only when `HCAPTCHA_SITE_KEY` is set.
- `settings/base.py` adds the two env vars (empty defaults). `.env.example` documents them with the dashboard URL.

## Test plan
- [x] manage.py test 42/42, flake8 clean
- [x] Empty keys: form renders without widget; POST flows through normally
- [x] Keys set: form renders widget; POST without token → 200 with 'Please complete the captcha' error