### PR TITLE
chore: Node 22 + section heading colour + drop digital-books open-link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,13 @@ ENV PYTHONUNBUFFERED=1 \
     PORT=8000
 
 # System dependencies for Wagtail, Pillow, the database client, GeoDjango
-# (libgdal for django-leaflet) and the asset pipeline.
+# (libgdal for django-leaflet) and the asset pipeline. Node 22 comes
+# from NodeSource — the Debian-bookworm package is Node 18, which can't
+# `require()` an ES Module, and our sass dependency pulls in
+# chokidar@4 which is ESM-only.
 RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-recommends \
     gnupg2 \
+    curl \
     ca-certificates \
     build-essential \
     libpq-dev \
@@ -24,8 +28,8 @@ RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-r
     libgdal-dev \
     gdal-bin \
     cron \
-    nodejs \
-    npm \
+ && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install --yes --quiet --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/*
 
 # Application server is installed via requirements.txt (the explicit

--- a/haskala/static/scss/_book_detail.scss
+++ b/haskala/static/scss/_book_detail.scss
@@ -137,7 +137,11 @@
 
   &__heading {
     margin-bottom: 1rem;
-    color: var(--bs-emphasis-color);
+    // The global h1-h6 rule already picks $haskala-base, but bootstrap's
+    // utility .h4 sneaks --bs-heading-color in via the h4 element-level
+    // style on the .index-group__heading h4 ancestor. Force the warm
+    // grey explicitly so dividers stay tonal with the body.
+    color: $haskala-base;
   }
 
   // Definition lists are the workhorse format on these pages.

--- a/haskala/templates/digital-books/digital_books_page.html
+++ b/haskala/templates/digital-books/digital_books_page.html
@@ -30,12 +30,6 @@
                                             &middot; {{ book.gregorian_year|default:book.year_in_book }}
                                         </span>
                                     {% endif %}
-                                    {% if book.digital_book_url %}
-                                        <a href="{{ book.digital_book_url }}" target="_blank" rel="noopener"
-                                           class="badge text-bg-secondary ms-2">
-                                            <i class="bi bi-box-arrow-up-right"></i> Open digital copy
-                                        </a>
-                                    {% endif %}
                                 </li>
                             {% endfor %}
                         </ul>


### PR DESCRIPTION
Three small follow-ups.

- **Dockerfile**: Node 22 from NodeSource replaces Debian-bookworm Node 18. Sass 1.95+ pulls in chokidar@4 which is ESM-only; Node 18 cannot `require()` an ES module, breaking `npm run build:css` during the image build.
- **`.book-section__heading`** forced to `color: $haskala-base` (#5e5d58). The previous `var(--bs-emphasis-color)` resolved to near-black because `.h4` injects `--bs-heading-color` and beats the global h1-h6 rule.
- **/digital-books/** drops the "Open digital copy" link per row. The badge button on the book detail page still surfaces the URL.

## Test plan
- [x] manage.py test 42/42
- [x] Compiled CSS: `.book-section__heading { ... color: #5e5d58 }`
- [x] /digital-books/ no longer contains "Open digital copy"