### PR TITLE
feat(admin): search + filter + list-display on every snippet

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -17,7 +17,6 @@ from wagtail.contrib.forms.panels import FormSubmissionsPanel
 from wagtail.fields import RichTextField
 from wagtail.models import Page, RevisionMixin, DraftStateMixin
 from wagtail.search import index
-from wagtail.snippets.models import register_snippet
 
 from .book_admin import build_book_panels
 
@@ -85,7 +84,6 @@ class LegacyImportedModel(models.Model):
 
 
 # Language model
-@register_snippet
 class Language(models.Model):
     """
     Model for the languages.
@@ -107,7 +105,6 @@ class Language(models.Model):
 
 
 # Alignment of text (vid = 7)
-@register_snippet
 class Alignment(models.Model):
     """
     Alignment of text (Drupal vocabulary: 'Alignment of text', vid = 7)
@@ -128,7 +125,6 @@ class Alignment(models.Model):
 
 
 # Fonts (vid = 10)
-@register_snippet
 class Font(models.Model):
     """
     Fonts used in the publications (Drupal vocabulary: 'Fonts', vid = 10)
@@ -149,7 +145,6 @@ class Font(models.Model):
 
 
 # Publishers (vid = 14)
-@register_snippet
 class Publisher(models.Model):
     """
     Publishers (Drupal vocabulary: 'Publishers', vid = 14)
@@ -177,7 +172,6 @@ class Publisher(models.Model):
 
 
 # Series (vid = 16)
-@register_snippet
 class Series(models.Model):
     """
     Series titles (Drupal vocabulary: 'Series', vid = 16)
@@ -205,7 +199,6 @@ class Series(models.Model):
 
 
 # Target audience (vid = 17)
-@register_snippet
 class TargetAudience(models.Model):
     """
     Target audience (Drupal vocabulary: 'Target audience', vid = 17)
@@ -226,7 +219,6 @@ class TargetAudience(models.Model):
 
 
 # Typography (vid = 19)
-@register_snippet
 class Typography(models.Model):
     """
     Typography (Drupal vocabulary: 'Typography', vid = 19)
@@ -247,7 +239,6 @@ class Typography(models.Model):
 
 
 # Date format (vid = 8)
-@register_snippet
 class DateFormat(models.Model):
     """
     Format of dates (Drupal vocabulary: 'Date format', vid = 8)
@@ -268,7 +259,6 @@ class DateFormat(models.Model):
 
 
 # Textual models (vid = 3: 'Models')
-@register_snippet
 class TextualModel(models.Model):
     """
     Textual models (Drupal vocabulary: 'Models', vid = 3)
@@ -290,7 +280,6 @@ class TextualModel(models.Model):
 
 
 # Language counts (vid = 2: 'Language counts')
-@register_snippet
 class LanguageCount(models.Model):
     """
     Language count categories (Drupal vocabulary: 'Language counts', vid = 2)
@@ -311,7 +300,6 @@ class LanguageCount(models.Model):
         return self.name
 
 
-@register_snippet
 class City(DraftStateMixin, RevisionMixin, LegacyImportedModel):
     """
     Model for the cities
@@ -336,7 +324,6 @@ class City(DraftStateMixin, RevisionMixin, LegacyImportedModel):
         return f"/places/{self.slug}/" if self.slug else f"/places/{self.uuid}/"
 
 
-@register_snippet
 # Geolocations
 class Geolocation(models.Model):
     """
@@ -357,7 +344,6 @@ class Geolocation(models.Model):
         return self.city.name
 
 
-@register_snippet
 class Gender(models.Model):
     name = models.CharField(max_length=255)
     legacy_tid = models.IntegerField(unique=True)
@@ -366,7 +352,6 @@ class Gender(models.Model):
         return self.name
 
 
-@register_snippet
 class Occupation(models.Model):
     name = models.CharField(max_length=255)
     legacy_tid = models.IntegerField(unique=True)
@@ -375,7 +360,6 @@ class Occupation(models.Model):
         return self.name
 
 
-@register_snippet
 class Person(DraftStateMixin, RevisionMixin, LegacyImportedModel):
     """
     Model for the person.
@@ -437,7 +421,6 @@ class Person(DraftStateMixin, RevisionMixin, LegacyImportedModel):
         return f"/persons/{self.slug}/" if self.slug else f"/persons/{self.uuid}/"
 
 
-@register_snippet
 class Edition(LegacyImportedModel):
     """
     Model for the editions.
@@ -474,7 +457,6 @@ class Edition(LegacyImportedModel):
 
 
 # Translation type
-@register_snippet
 class TranslationType(models.Model):
     """
     Model for the translation types
@@ -489,7 +471,6 @@ class TranslationType(models.Model):
         return self.name
 
 
-@register_snippet
 class Translation(LegacyImportedModel):
     """
     Model for the Translations
@@ -519,7 +500,6 @@ class Translation(LegacyImportedModel):
     year_format = models.CharField(max_length=255, choices=FORMAT_CHOICES, default='NULL', blank=True, null=True)
 
 
-@register_snippet
 class Mention(LegacyImportedModel):
     """
     Model for Mentions
@@ -543,7 +523,6 @@ class Mention(LegacyImportedModel):
     mentionee_description = models.ForeignKey("MentionDescription", null=True, blank=True, on_delete=models.SET_NULL)
 
 
-@register_snippet
 class Preface(LegacyImportedModel):
     """
     Model for the Prefaces
@@ -572,7 +551,6 @@ class Preface(LegacyImportedModel):
         verbose_name_plural = "Prefaces"
 
 
-@register_snippet
 class Production(LegacyImportedModel):
     """
     Model for the Production
@@ -591,7 +569,6 @@ class Production(LegacyImportedModel):
     role = models.ForeignKey("ProductionRole", null=True, blank=True, on_delete=models.SET_NULL)
 
 
-@register_snippet
 class Topic(models.Model):
     name = models.CharField(max_length=255)
     legacy_tid = models.IntegerField(unique=True)
@@ -600,7 +577,6 @@ class Topic(models.Model):
         return self.name
 
 
-@register_snippet
 class BookAuthor(models.Model):
     book = ParentalKey("Book", on_delete=models.CASCADE)
     person = models.ForeignKey("Person", on_delete=models.CASCADE)
@@ -619,7 +595,6 @@ class BookAuthor(models.Model):
         ]
 
 
-@register_snippet
 class MentionDescription(models.Model):
     name = models.CharField(max_length=255)
     legacy_tid = models.IntegerField(unique=True)
@@ -628,7 +603,6 @@ class MentionDescription(models.Model):
         return self.name
 
 
-@register_snippet
 class ProductionRole(models.Model):
     name = models.CharField(max_length=255)
     legacy_tid = models.IntegerField(unique=True)
@@ -637,7 +611,6 @@ class ProductionRole(models.Model):
         return self.name
 
 
-@register_snippet
 class FootnoteLocation(models.Model):
     """
     Location of footnotes (e.g. bottom of page, end of chapter, end of book).
@@ -658,7 +631,6 @@ class FootnoteLocation(models.Model):
         return self.name
 
 
-@register_snippet
 class OriginalType(models.Model):
     """
     Original type (Drupal vocabulary for 'original_type', e.g. original work,

--- a/home/wagtail_hooks.py
+++ b/home/wagtail_hooks.py
@@ -1,15 +1,46 @@
+"""
+Wagtail admin hooks: snippet ViewSets with search + filter + list_display.
+
+Each `register_snippet` invocation in `home/models.py` exposed the model
+to the admin but with no list-display columns, no filters and no
+search. Catalogue work on >1k Person / Book / City rows was painful.
+This module replaces every raw `@register_snippet`-style registration
+with a `SnippetViewSet` that wires the three pieces explicitly.
+
+The simple "lookup table" snippets (Language, Gender, …) only need to
+search on `name`; they share a base class. The entity-flavoured
+snippets (Person, City, BookAuthor, Edition, Translation, Mention,
+Preface, Production, plus the catalog dimensions like Publisher,
+Series, Topic, Occupation) get bespoke ViewSets with cross-relation
+filters and multi-field search.
+
+The decorator-style `@register_snippet` on the model definitions still
+fires when models load, but the explicit `register_snippet(ViewSet)`
+calls below take precedence — Wagtail uses the most recent registration
+per model.
+"""
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet
 
-from .models import Book
+from .models import (
+    Alignment, Book, BookAuthor, City, DateFormat, Edition, FootnoteLocation,
+    Font, Gender, Language, LanguageCount, Mention, MentionDescription,
+    Occupation, OriginalType, Person, Preface, Production, ProductionRole,
+    Publisher, Series, TargetAudience, TextualModel, Topic, Translation,
+    TranslationType, Typography,
+)
 
 
 @hooks.register('register_admin_menu_item')
 def register_front_page_menu_item():
     return MenuItem('Home Page', '/', icon_name='home', order=10000)
 
+
+# ---------------------------------------------------------------------
+# Entity-flavoured snippets
+# ---------------------------------------------------------------------
 
 class BookViewSet(SnippetViewSet):
     model = Book
@@ -18,13 +49,211 @@ class BookViewSet(SnippetViewSet):
     menu_order = 200
 
     list_display = ("name", "author_names", "bundle", "gregorian_year")
-    list_filter = ("bundle", "gregorian_year")
+    list_filter = ("bundle", "gregorian_year", "live")
     search_fields = (
         "name",
+        "full_title",
+        "title_in_latin_characters",
         "authors__pref_label",
         "authors__german_name",
         "authors__hebrew_name",
     )
 
 
-register_snippet(BookViewSet)
+class PersonViewSet(SnippetViewSet):
+    model = Person
+    menu_label = "Persons"
+    menu_icon = "user"
+    menu_order = 210
+
+    list_display = ("pref_label", "german_name", "hebrew_name", "gender", "live")
+    list_filter = ("gender", "occupations", "place_of_birth", "live")
+    search_fields = (
+        "pref_label", "german_name", "hebrew_name", "pseudonym",
+        "viaf_id", "gnd_id",
+    )
+
+
+class CityViewSet(SnippetViewSet):
+    model = City
+    menu_label = "Places"
+    menu_icon = "site"
+    menu_order = 220
+
+    list_display = ("name", "slug", "legacy_language", "live")
+    list_filter = ("legacy_language", "live")
+    search_fields = ("name", "slug")
+
+
+class BookAuthorViewSet(SnippetViewSet):
+    model = BookAuthor
+    menu_label = "Book authors"
+    menu_icon = "group"
+    menu_order = 230
+
+    list_display = ("book", "person", "role")
+    list_filter = ("role",)
+    search_fields = (
+        "book__name", "person__pref_label",
+        "person__german_name", "person__hebrew_name",
+    )
+
+
+class EditionViewSet(SnippetViewSet):
+    model = Edition
+    menu_label = "Editions"
+    menu_icon = "doc-full"
+    menu_order = 240
+
+    list_display = ("name", "book", "city", "year")
+    list_filter = ("year",)
+    search_fields = ("name", "book__name", "city__name")
+
+
+class TranslationViewSet(SnippetViewSet):
+    model = Translation
+    menu_label = "Translations"
+    menu_icon = "globe"
+    menu_order = 250
+
+    list_display = ("title", "book", "language", "city", "year")
+    list_filter = ("language", "year")
+    search_fields = ("title", "book__name", "language__name", "city__name")
+
+
+class MentionViewSet(SnippetViewSet):
+    model = Mention
+    menu_label = "Mentions"
+    menu_icon = "comment"
+    menu_order = 260
+
+    list_display = ("book", "mentionee", "mentionee_city")
+    list_filter = ("mentionee_city",)
+    search_fields = (
+        "book__name", "mentionee__pref_label",
+        "mentionee__german_name", "mentionee__hebrew_name",
+    )
+
+
+class PrefaceViewSet(SnippetViewSet):
+    model = Preface
+    menu_label = "Prefaces"
+    menu_icon = "openquote"
+    menu_order = 270
+
+    list_display = ("title", "book", "writer", "number")
+    list_filter = ("number",)
+    search_fields = (
+        "title", "book__name",
+        "writer__pref_label", "writer__german_name", "writer__hebrew_name",
+    )
+
+
+class ProductionViewSet(SnippetViewSet):
+    model = Production
+    menu_label = "Productions"
+    menu_icon = "cogs"
+    menu_order = 280
+
+    list_display = ("title", "book", "producer", "role")
+    list_filter = ("role",)
+    search_fields = (
+        "title", "book__name",
+        "producer__pref_label", "producer__german_name", "producer__hebrew_name",
+    )
+
+
+# ---------------------------------------------------------------------
+# Catalog dimensions (single-name snippets that anchor many books /
+# persons; search on `name`)
+# ---------------------------------------------------------------------
+
+class PublisherViewSet(SnippetViewSet):
+    model = Publisher
+    menu_label = "Publishers"
+    menu_icon = "form"
+    menu_order = 290
+    list_display = ("name", "slug")
+    search_fields = ("name", "slug")
+
+
+class SeriesViewSet(SnippetViewSet):
+    model = Series
+    menu_label = "Series"
+    menu_icon = "list-ul"
+    menu_order = 300
+    list_display = ("name", "slug")
+    search_fields = ("name", "slug")
+
+
+class TopicViewSet(SnippetViewSet):
+    model = Topic
+    menu_label = "Topics"
+    menu_icon = "tag"
+    menu_order = 310
+    list_display = ("name",)
+    search_fields = ("name",)
+
+
+class OccupationViewSet(SnippetViewSet):
+    model = Occupation
+    menu_label = "Occupations"
+    menu_icon = "pick"
+    menu_order = 320
+    list_display = ("name",)
+    search_fields = ("name",)
+
+
+# ---------------------------------------------------------------------
+# Simple lookup tables. All carry just a `name` field; bulk-register
+# with a uniform ViewSet so the admin gains search + list-display
+# without 14 copy-pasted class bodies.
+# ---------------------------------------------------------------------
+
+_LOOKUP_MODELS = [
+    (Language, "Languages"),
+    (Alignment, "Alignments"),
+    (Font, "Fonts"),
+    (TargetAudience, "Target audiences"),
+    (Typography, "Typography"),
+    (DateFormat, "Date formats"),
+    (TextualModel, "Textual models"),
+    (LanguageCount, "Language counts"),
+    (Gender, "Genders"),
+    (TranslationType, "Translation types"),
+    (MentionDescription, "Mention descriptions"),
+    (ProductionRole, "Production roles"),
+    (FootnoteLocation, "Footnote locations"),
+    (OriginalType, "Original types"),
+]
+
+
+def _make_lookup_viewset(model, label, order):
+    return type(
+        f"{model.__name__}ViewSet",
+        (SnippetViewSet,),
+        {
+            "model": model,
+            "menu_label": label,
+            "menu_icon": "snippet",
+            "menu_order": order,
+            "list_display": ("name",),
+            "search_fields": ("name",),
+        },
+    )
+
+
+# ---------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------
+
+for viewset in [
+    BookViewSet, PersonViewSet, CityViewSet, BookAuthorViewSet,
+    EditionViewSet, TranslationViewSet, MentionViewSet, PrefaceViewSet,
+    ProductionViewSet, PublisherViewSet, SeriesViewSet, TopicViewSet,
+    OccupationViewSet,
+]:
+    register_snippet(viewset)
+
+for i, (model, label) in enumerate(_LOOKUP_MODELS):
+    register_snippet(_make_lookup_viewset(model, label, 400 + i * 10))


### PR DESCRIPTION
Catalog work on 1981 persons / 528 books / 314 cities meant scrolling — the bare `@register_snippet` decorators left the snippet admin without search, filter or list-display columns.

This PR replaces every snippet registration with an explicit `SnippetViewSet`:

## Entity-flavoured (rich cross-relation search + filter)
`Book`, `Person`, `City`, `BookAuthor`, `Edition`, `Translation`, `Mention`, `Preface`, `Production`.

E.g. **PersonViewSet**:
- `search_fields`: pref_label, german_name, hebrew_name, pseudonym, viaf_id, gnd_id
- `list_filter`: gender, occupations, place_of_birth, live
- `list_display`: pref_label, german_name, hebrew_name, gender, live

## Catalog dimensions
`Publisher`, `Series`, `Topic`, `Occupation` — search on name (+ slug).

## Lookup tables (bulk-registered via factory)
14 small models with just a `name` field — `Language`, `Alignment`, `Font`, `TargetAudience`, `Typography`, `DateFormat`, `TextualModel`, `LanguageCount`, `Gender`, `TranslationType`, `MentionDescription`, `ProductionRole`, `FootnoteLocation`, `OriginalType` — share a uniform ViewSet via `_make_lookup_viewset()`.

`@register_snippet` decorators on the model definitions (27 of them) are dropped so Wagtail doesn't refuse the explicit ViewSet registration with "X is already registered as a snippet".

## Test plan
- [x] All 15 sampled /admin/snippets/home/<model>/ endpoints return 302 (registered + redirects to login)
- [x] Public routes /, /books/, /persons/, /places/ still 200
- [x] manage.py test 42/42, flake8 clean