### PR TITLE
chore(footer): add Contact link to the About column

### DIFF
--- a/haskala/templates/partials/footermenu.html
+++ b/haskala/templates/partials/footermenu.html
@@ -27,6 +27,7 @@
                 <h2 class="h6 text-uppercase text-muted mb-2">About</h2>
                 <ul class="list-unstyled mb-0">
                     <li><a href="/about/">About this project</a></li>
+                    <li><a href="/contact/">Contact</a></li>
                     <li><a href="/dashboard">Login</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
The /contact/ Wagtail FormPage with the hCaptcha challenge (PR #73) was live but unreachable from the public site. Add a 'Contact' list item to the existing footer 'About' column.

No new page or migration — the ContactPage instance is already in Wagtail (slug=contact, live=True, form fields: Email, Subject, Message).