### PR TITLE
style(contact): left-align the contact form

### DIFF
--- a/haskala/templates/contact/contact_page.html
+++ b/haskala/templates/contact/contact_page.html
@@ -4,7 +4,7 @@
 {% block title %}{{ page.title }}{% endblock %}
 
 {% block content %}
-<div class="container my-5">
+<div class="container my-5 text-start">
     <div class="row justify-content-center">
         <div class="col-lg-8">
 


### PR DESCRIPTION
Add `text-start` to the /contact/ container so the form labels and inputs flow left-aligned instead of inheriting the global `body { text-align: center }`.