### PR TITLE
feat(contact): render via crispy-forms + send icon

### DIFF
--- a/haskala/settings/base.py
+++ b/haskala/settings/base.py
@@ -70,7 +70,14 @@ INSTALLED_APPS = [
     "django_filters",
     "drf_spectacular",
     "djangordf",
+    "crispy_forms",
+    "crispy_bootstrap5",
 ]
+
+# Tell django-crispy-forms to render via the Bootstrap-5 template pack
+# (matches the rest of the public theme).
+CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
+CRISPY_TEMPLATE_PACK = "bootstrap5"
 
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/haskala/templates/contact/contact_page.html
+++ b/haskala/templates/contact/contact_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags %}
+{% load wagtailcore_tags crispy_forms_tags %}
 
 {% block title %}{{ page.title }}{% endblock %}
 
@@ -38,7 +38,7 @@
                             </div>
                         {% endif %}
 
-                        {{ form.as_p }}
+                        {{ form|crispy }}
 
                         {% if HCAPTCHA_SITE_KEY %}
                             {# hCaptcha challenge. Renders an iframe + a
@@ -54,7 +54,7 @@
                         {% endif %}
 
                         <button type="submit" class="btn btn-primary">
-                            Send message
+                            <i class="bi bi-send"></i> Send message
                         </button>
                     </form>
                 </div>


### PR DESCRIPTION
Wire up the already-installed `django-crispy-forms` + `crispy-bootstrap5` packages so the contact form picks up proper Bootstrap-5 `form-label` / `form-control` / `mb-3` / `requiredField` markup instead of the raw `{{ form.as_p }}` output.

- `INSTALLED_APPS` gains `crispy_forms` + `crispy_bootstrap5`.
- `CRISPY_TEMPLATE_PACK = "bootstrap5"`.
- Template switches `{{ form.as_p }}` → `{{ form|crispy }}` (keeps the surrounding `<form>` + hCaptcha + submit button).
- Send button leads with `<i class="bi bi-send">` (bootstrap-icons send glyph).

## Test plan
- [x] /contact/ HTTP 200
- [x] Crispy renders email / subject / message with `form-control` + `form-label requiredField` + asterisk
- [x] manage.py test 42/42, flake8 clean