### PR TITLE
fix(contact): CSRF cookie + HTML5 form validation

### DIFF
--- a/haskala/templates/contact/contact_page.html
+++ b/haskala/templates/contact/contact_page.html
@@ -28,7 +28,7 @@
 
             <div class="card shadow-sm">
                 <div class="card-body">
-                    <form action="{% pageurl page %}" method="POST" novalidate>
+                    <form action="{% pageurl page %}" method="POST">
                         {% csrf_token %}
 
                         {# Form-Fehler oben gesammelt #}

--- a/home/models.py
+++ b/home/models.py
@@ -8,7 +8,7 @@ from django.template.defaultfilters import slugify
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
-from django.views.decorators.cache import cache_page
+from django.views.decorators.cache import cache_page, never_cache
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel, InlinePanel, FieldRowPanel
@@ -1475,6 +1475,11 @@ class ContactPage(AbstractEmailForm):
     template = "contact/contact_page.html"
     landing_page_template = "contact/contact_page_landing.html"
 
+    # The global `UpdateCacheMiddleware` would otherwise cache the
+    # GET response and strip the CSRF cookie, so a subsequent POST
+    # would fail with "CSRF cookie not set". Mark the page as
+    # never-cached so the token is set on every visit.
+    @method_decorator(never_cache)
     def serve(self, request, *args, **kwargs):
         """
         Handle form display + submission with success/error messages.


### PR DESCRIPTION
Two bugs the user hit while submitting the contact form for real.

**CSRF cookie not set (HTTP 403)** — the global `UpdateCacheMiddleware` was caching the GET response of /contact/ for 10 minutes, which strips the `Set-Cookie: csrftoken=...` header. The subsequent POST then failed with "CSRF cookie not set". `ContactPage.serve()` is now decorated with `@method_decorator(never_cache)` so every GET ships the token cookie.

**HTML5 validation off** — the `<form>` carried `novalidate`, so empty fields would submit and bounce through server-side validation with a generic error. Drop `novalidate`. The fields rendered by django-crispy-forms (PR #79) already carry the `required` attribute, so the existing validation contract carries over.

## Test plan
- [x] GET /contact/ now ships `Set-Cookie: csrftoken=...`
- [x] POST with the token returns HTTP 200 (no more 403)
- [x] manage.py test 42/42, flake8 clean