### PR TITLE
fix(contact): end-to-end mail delivery + hCaptcha policy

### DIFF
--- a/haskala/settings/base.py
+++ b/haskala/settings/base.py
@@ -454,5 +454,13 @@ EMAIL_USE_TLS = env("EMAIL_USE_TLS", default=True, cast=bool)
 EMAIL_HOST_USER = env("EMAIL_HOST_USER", default="")
 EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD", default="")
 
-DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="")
-SERVER_EMAIL = env("SERVER_EMAIL", default="")
+# `or` lets an empty .env entry fall back to the safe default — the
+# repository ships .env with DEFAULT_FROM_EMAIL="" which would
+# otherwise win over the env()-level default.
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="") or "noreply@haskala.local"
+SERVER_EMAIL = env("SERVER_EMAIL", default="") or DEFAULT_FROM_EMAIL
+
+# Recipient inbox for the public /contact/ form when the Wagtail page's
+# own `to_address` field is empty. Set CONTACT_TO_EMAIL via .env to
+# override.
+CONTACT_TO_EMAIL = env("CONTACT_TO_EMAIL", default="") or DEFAULT_FROM_EMAIL

--- a/haskala/settings/dev.py
+++ b/haskala/settings/dev.py
@@ -15,8 +15,14 @@ CSRF_TRUSTED_ORIGINS = [
     "http://127.0.0.1:8080",
 ]
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
+# Dev sends through the bundled MailHog service (host:port from
+# base.py's EMAIL_HOST / EMAIL_PORT env-overrides; in the docker
+# stack the web container reaches MailHog as mailserver:1025 and
+# the inbox UI is at http://localhost:8025/). MailHog is a plain
+# SMTP sink — no STARTTLS / SSL.
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_USE_TLS = False
+EMAIL_USE_SSL = False
 
 try:
     from .local import *  # noqa: F401,F403

--- a/home/models.py
+++ b/home/models.py
@@ -1509,7 +1509,7 @@ class ContactPage(AbstractEmailForm):
                     # Standard handling from AbstractEmailForm:
                     # - send email
                     # - save submission
-                    self.process_form(form)
+                    self.process_form_submission(form)
                 except Exception:
                     messages.error(
                         request,
@@ -1532,7 +1532,8 @@ class ContactPage(AbstractEmailForm):
                 )
 
                 # Render landing page (thank-you page)
-                context = self.get_landing_page_context(request, form=form)
+                context = self.get_context(request)
+                context["form"] = form
                 return TemplateResponse(
                     request,
                     self.get_landing_page_template(request),
@@ -1606,6 +1607,34 @@ class ContactPage(AbstractEmailForm):
         if data.get("success"):
             return None
         return "Captcha verification failed. Please try again."
+
+    def _populate_email_defaults(self):
+        """Fill the page's to_address / from_address from
+        settings.CONTACT_TO_EMAIL / DEFAULT_FROM_EMAIL when the
+        editor has left them blank in Wagtail. Mutates self
+        in-memory only — values are not persisted to the page row.
+        """
+        from django.conf import settings as dj_settings
+        if not self.to_address:
+            self.to_address = getattr(
+                dj_settings, "CONTACT_TO_EMAIL", ""
+            ) or dj_settings.DEFAULT_FROM_EMAIL
+        if not self.from_address:
+            self.from_address = dj_settings.DEFAULT_FROM_EMAIL
+
+    def process_form_submission(self, form):
+        # Wagtail's base only calls send_mail when self.to_address is
+        # truthy. Populate the default addresses BEFORE calling super
+        # so the mail goes out even on a freshly-created ContactPage
+        # without manually configured recipient fields.
+        self._populate_email_defaults()
+        return super().process_form_submission(form)
+
+    def send_mail(self, form):
+        # Defence in depth: any direct caller of send_mail (e.g. tests)
+        # also picks up the defaults.
+        self._populate_email_defaults()
+        super().send_mail(form)
 
 
 class BookDetailPage(Page):


### PR DESCRIPTION
Three orthogonal bugs piled up on the live /contact/ submission. Sort them out + nail down the hCaptcha behaviour.

## Bugs fixed
- `ContactPage.serve()` called the non-existent `self.process_form(form)` (correct: `self.process_form_submission`). The AttributeError was swallowed by `except Exception` and surfaced as the generic "There was an error" alert.
- `self.get_landing_page_context(...)` also doesn't exist on `AbstractEmailForm`. Replaced with a direct `self.get_context(request)` call.
- Wagtail's base `process_form_submission` only invokes `send_mail` when `self.to_address` is truthy. New `_populate_email_defaults()` helper fills `to_address` / `from_address` from `settings.CONTACT_TO_EMAIL` / `DEFAULT_FROM_EMAIL` in memory before calling `super()`. Mutations are not persisted.

## Settings
- `DEFAULT_FROM_EMAIL`, `SERVER_EMAIL`, `CONTACT_TO_EMAIL` all fall back to `noreply@haskala.local` via the `env("") or "..."` pattern, so a shipped `.env` with empty values doesn't break delivery.
- Dev switches `EMAIL_BACKEND` from console to SMTP; `EMAIL_USE_TLS`/`EMAIL_USE_SSL` forced False (MailHog rejects STARTTLS).

## hCaptcha policy (no code change)
The existing wiring from PR #73 already honors the policy the user asked for:
- `HCAPTCHA_SITE_KEY` empty → widget is not rendered.
- `HCAPTCHA_SECRET_KEY` empty → server-side verify returns success without calling siteverify.
- Both keys must come from `.env` for a live deploy. `.env.example` already documents the dashboard URL.

## Test plan
- [x] POST /contact/ returns HTTP 200 with "Thank you" + alert-success
- [x] MailHog inbox carries one message with From/To/Subject/Body filled
- [x] With hCaptcha keys set: POST without h-captcha-response is rejected with "Please complete the captcha"; POST with the official test token passes
- [x] manage.py test 42/42, flake8 clean