### PR TITLE
chore(contact): drop the hCaptcha widget comment

### DIFF
--- a/haskala/templates/contact/contact_page.html
+++ b/haskala/templates/contact/contact_page.html
@@ -41,9 +41,6 @@
                         {{ form|crispy }}
 
                         {% if HCAPTCHA_SITE_KEY %}
-                            {# hCaptcha challenge. Renders an iframe + a
-                               hidden h-captcha-response field that the
-                               server verifies in ContactPage.serve(). #}
                             <div class="mb-3">
                                 <div class="h-captcha" data-sitekey="{{ HCAPTCHA_SITE_KEY }}"></div>
                                 {% if hcaptcha_error %}


### PR DESCRIPTION
Drop the verbose Django template comment above the hCaptcha widget. The if-block + sitekey speak for themselves.