### PR TITLE
fix(contact): hCaptcha disabled when either key is missing

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -1581,8 +1581,11 @@ class ContactPage(AbstractEmailForm):
         from django.conf import settings as dj_settings
 
         secret = getattr(dj_settings, "HCAPTCHA_SECRET_KEY", "") or ""
-        if not secret:
-            # hCaptcha disabled; treat every submission as verified.
+        site = getattr(dj_settings, "HCAPTCHA_SITE_KEY", "") or ""
+        if not secret or not site:
+            # Either half of the hCaptcha config missing → feature
+            # disabled. The widget isn't rendered (template gates on
+            # SITE_KEY) and no submission is verified.
             return None
 
         token = request.POST.get("h-captcha-response", "")


### PR DESCRIPTION
User policy: missing API key → no widget + no verification.

The template already gated the widget on `HCAPTCHA_SITE_KEY`, but `_verify_hcaptcha()` only checked `HCAPTCHA_SECRET_KEY`. With secret set but site key missing the form would silently reject every submission as 'Please complete the captcha'. Now the verify path bails symmetrically — both keys must be set for hCaptcha to engage.