### PR TITLE
chore(persons): occupation chip padding + drop dir=rtl on hebrew_name

### DIFF
--- a/haskala/templates/persons/_person_header.html
+++ b/haskala/templates/persons/_person_header.html
@@ -24,7 +24,7 @@
         <p class="person-header__chips mb-2">
             {% for occ in person.occupations.all %}
                 <a href="{% url 'occupation-detail' occ.name|slugify %}"
-                   class="badge rounded-pill text-bg-light border text-decoration-none">
+                   class="badge p-2 rounded-pill text-bg-light border text-decoration-none">
                     {{ occ.name }}
                 </a>{% if not forloop.last %} {% endif %}
             {% endfor %}

--- a/haskala/templates/persons/_sections/identity.html
+++ b/haskala/templates/persons/_sections/identity.html
@@ -10,7 +10,7 @@
     {% endif %}
     {% if person.hebrew_name|clean_value %}
         <dt class="col-sm-4">Hebrew name</dt>
-        <dd class="col-sm-8" lang="he" dir="rtl">{{ person.hebrew_name|clean_value }}</dd>
+        <dd class="col-sm-8" lang="he">{{ person.hebrew_name|clean_value }}</dd>
     {% endif %}
     {% if person.pseudonym|clean_value %}
         <dt class="col-sm-4">Pseudonym</dt>


### PR DESCRIPTION
Two manual template tweaks from the live review:

- Occupation chips on the person header now use `p-2` for proper rounded-pill padding.
- Hebrew name cell drops `dir="rtl"`; `lang="he"` alone handles the script direction within the inline flow.