### PR TITLE
chore(layout): static pages full-width + occupation chips on secondary

### DIFF
--- a/haskala/templates/home/static_page.html
+++ b/haskala/templates/home/static_page.html
@@ -6,7 +6,7 @@
 {% block content %}
     <div class="container static-page my-4">
         <div class="row">
-            <article class="col-md-9 col-lg-8 mx-auto">
+            <article class="col-md-12 col-lg-12 mx-auto">
                 <header class="static-page__header mb-4">
                     <p class="text-muted small mb-1">
                         <a href="/">Home</a>

--- a/haskala/templates/persons/_person_header.html
+++ b/haskala/templates/persons/_person_header.html
@@ -24,7 +24,7 @@
         <p class="person-header__chips mb-2">
             {% for occ in person.occupations.all %}
                 <a href="{% url 'occupation-detail' occ.name|slugify %}"
-                   class="badge p-2 rounded-pill text-bg-light border text-decoration-none">
+                   class="badge p-2 rounded-pill text-bg-secondary border text-decoration-none">
                     {{ occ.name }}
                 </a>{% if not forloop.last %} {% endif %}
             {% endfor %}


### PR DESCRIPTION
Two manual tweaks:

- Static pages (legal-notice, privacy-policy, cookie-policy, accessibility) drop the narrow `col-lg-8` constraint; the article spans the full `col-12`.
- Occupation chips on the Person header move from `text-bg-light` to `text-bg-secondary` so they match the rest of the badge palette.