### PR TITLE
style(search): center facets + left-align results + badge tweaks

### DIFF
--- a/haskala/static/scss/_book_detail.scss
+++ b/haskala/static/scss/_book_detail.scss
@@ -183,11 +183,23 @@
 // Search results page — chip-style facet bar that replaces the
 // dropdown "Result type" select. The active facet uses the brand
 // blue fill; inactive facets read as outlined neutrals.
+// The page body uses text-align: start (see .search-page below) so
+// result lists read flush-left; the facet chip bar overrides this
+// with justify-content: center so the chips sit balanced above the
+// results.
 .search-facets {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.5rem;
   margin-bottom: 1rem;
+}
+
+// Search page body — list items + result rows flow from the start
+// edge. The global body { text-align: center } would otherwise
+// center every result line.
+.search-page {
+  text-align: start;
 }
 
 .search-facet {

--- a/haskala/templates/books/_book_header.html
+++ b/haskala/templates/books/_book_header.html
@@ -31,7 +31,7 @@
     <div class="book-header__actions">
         {% if book.digital_book_url %}
             <a href="{{ book.digital_book_url }}" target="_blank" rel="noopener"
-               class="btn btn-sm btn-secondary">
+               class="badge btn-secondary text-light">
                 <i class="bi bi-book"></i> View digital copy
             </a>
         {% endif %}

--- a/haskala/templates/search/search_results.html
+++ b/haskala/templates/search/search_results.html
@@ -16,7 +16,7 @@
                             type="text"
                             name="q"
                             id="id_q"
-                            class="form-control form-control-lg"
+                            class="form-control"
                             value="{{ query }}"
                             placeholder="Search in books, persons, places…"
                             aria-label="Search"
@@ -25,7 +25,7 @@
                 </div>
                 <div class="col-md-3 d-flex gap-2">
                     <button type="submit" class="btn btn-primary flex-grow-1">Search</button>
-                    <a href="{% url 'search' %}" class="btn btn-secondary">Reset</a>
+                    <a href="{% url 'search' %}" class="btn text-bg-secondary">Reset</a>
                 </div>
             </div>
 


### PR DESCRIPTION
Three tweaks bundled:

- `.search-facets` gets `justify-content: center` to keep the chip bar balanced.
- New `.search-page { text-align: start }` so result list items flow flush-left.
- Manual: search Reset uses `.btn.text-bg-secondary`, View-digital-copy uses `.badge.btn-secondary.text-light`, query input drops `form-control-lg`.