### PR TITLE
style(rtl): dir=auto on every detail-section dd

### DIFF
--- a/haskala/templates/books/_sections/authors.html
+++ b/haskala/templates/books/_sections/authors.html
@@ -18,26 +18,26 @@
 <dl class="row mb-0">
     {% if book.original_author|clean_value %}
         <dt class="col-sm-4">Original author</dt>
-        <dd class="col-sm-8">{{ book.original_author|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_author|clean_value }}</dd>
     {% endif %}
     {% if book.original_author_else_refer|clean_value %}
         <dt class="col-sm-4">Original author (reference)</dt>
-        <dd class="col-sm-8">{{ book.original_author_else_refer|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_author_else_refer|clean_value }}</dd>
     {% endif %}
     {% if book.original_author_elsewhere|clean_value %}
         <dt class="col-sm-4">Original author elsewhere</dt>
-        <dd class="col-sm-8">{{ book.original_author_elsewhere|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_author_elsewhere|clean_value }}</dd>
     {% endif %}
     {% if book.original_author_other_name|clean_value %}
         <dt class="col-sm-4">Original author (other name)</dt>
-        <dd class="col-sm-8">{{ book.original_author_other_name|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_author_other_name|clean_value }}</dd>
     {% endif %}
     {% if book.founders|clean_value %}
         <dt class="col-sm-4">Founders</dt>
-        <dd class="col-sm-8">{{ book.founders|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.founders|clean_value }}</dd>
     {% endif %}
     {% if book.proofreaders|clean_value %}
         <dt class="col-sm-4">Proofreaders</dt>
-        <dd class="col-sm-8">{{ book.proofreaders|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.proofreaders|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/availability.html
+++ b/haskala/templates/books/_sections/availability.html
@@ -3,15 +3,15 @@
 <dl class="row mb-0">
     {% if book.not_available|clean_value %}
         <dt class="col-sm-4">Availability</dt>
-        <dd class="col-sm-8"><span class="text-warning">Not currently available</span></dd>
+        <dd class="col-sm-8" dir="auto"><span class="text-warning">Not currently available</span></dd>
     {% endif %}
     {% if book.availability_notes|clean_value %}
         <dt class="col-sm-4">Availability notes</dt>
-        <dd class="col-sm-8">{{ book.availability_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.availability_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.digital_book_url|clean_value %}
         <dt class="col-sm-4">Digital copy</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             <a href="{{ book.digital_book_url|clean_value }}" target="_blank" rel="noopener">
                 {{ book.digital_book_title|default:"Open digital copy" }}
                 <i class="bi bi-box-arrow-up-right small"></i>
@@ -23,7 +23,7 @@
     {% endif %}
     {% if book.other_libraries|clean_value %}
         <dt class="col-sm-4">Other libraries</dt>
-        <dd class="col-sm-8">{{ book.other_libraries|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.other_libraries|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>
 
@@ -33,7 +33,7 @@
         {% for label, value, key in book|catalog_ids %}
             {% if value %}
                 <dt class="col-sm-4">{{ label }}</dt>
-                <dd class="col-sm-8">
+                <dd class="col-sm-8" dir="auto">
                     {% with link=value|library_catalog_url:key %}
                         {% if link %}
                             <a href="{{ link }}" target="_blank" rel="noopener">
@@ -53,10 +53,10 @@
 <dl class="row mb-0 mt-3">
     {% if book.preservation_references|clean_value %}
         <dt class="col-sm-4">Preservation references</dt>
-        <dd class="col-sm-8">{{ book.preservation_references|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.preservation_references|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.catalog_numbers_notes|clean_value %}
         <dt class="col-sm-4">Catalog number notes</dt>
-        <dd class="col-sm-8">{{ book.catalog_numbers_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.catalog_numbers_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/censorship.html
+++ b/haskala/templates/books/_sections/censorship.html
@@ -2,18 +2,18 @@
 <dl class="row mb-0">
     {% if book.censorship|clean_value %}
         <dt class="col-sm-4">Censorship</dt>
-        <dd class="col-sm-8">{{ book.censorship|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.censorship|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.bans|clean_value %}
         <dt class="col-sm-4">Bans</dt>
-        <dd class="col-sm-8">{{ book.bans|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.bans|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.rabbinical_approbations|clean_value %}
         <dt class="col-sm-4">Rabbinical approbations</dt>
-        <dd class="col-sm-8">{{ book.rabbinical_approbations|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.rabbinical_approbations|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.rabbinical_approbation_notes|clean_value %}
         <dt class="col-sm-4">Approbation notes</dt>
-        <dd class="col-sm-8">{{ book.rabbinical_approbation_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.rabbinical_approbation_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/content_structure.html
+++ b/haskala/templates/books/_sections/content_structure.html
@@ -2,74 +2,74 @@
 <dl class="row mb-0">
     {% if book.topic|clean_value %}
         <dt class="col-sm-4">Topic</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             <a href="{% url 'topic-detail' book.topic.name|slugify %}">{{ book.topic.name }}</a>
         </dd>
     {% endif %}
     {% if book.target_audience.all %}
         <dt class="col-sm-4">Target audience</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% for ta in book.target_audience.all %}{{ ta.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
     {% if book.target_audience_notes|clean_value %}
         <dt class="col-sm-4">Target audience notes</dt>
-        <dd class="col-sm-8">{{ book.target_audience_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.target_audience_notes|clean_value }}</dd>
     {% endif %}
     {% if book.original_type|clean_value %}
         <dt class="col-sm-4">Original type</dt>
-        <dd class="col-sm-8">{{ book.original_type.name }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_type.name }}</dd>
     {% endif %}
     {% if book.main_textual_models.all %}
         <dt class="col-sm-4">Main textual models</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% for tm in book.main_textual_models.all %}{{ tm.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
     {% if book.secondary_textual_models.all %}
         <dt class="col-sm-4">Secondary textual models</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% for tm in book.secondary_textual_models.all %}{{ tm.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
     {% if book.textual_model_notes|clean_value %}
         <dt class="col-sm-4">Textual model notes</dt>
-        <dd class="col-sm-8">{{ book.textual_model_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.textual_model_notes|clean_value }}</dd>
     {% endif %}
     {% if book.structure_notes|clean_value %}
         <dt class="col-sm-4">Structure notes</dt>
-        <dd class="col-sm-8">{{ book.structure_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.structure_notes|clean_value }}</dd>
     {% endif %}
     {% if book.structure_preface_notes|clean_value %}
         <dt class="col-sm-4">Structure / preface notes</dt>
-        <dd class="col-sm-8">{{ book.structure_preface_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.structure_preface_notes|clean_value }}</dd>
     {% endif %}
     {% if book.table_of_content|clean_value %}
         <dt class="col-sm-4">Table of contents</dt>
-        <dd class="col-sm-8">{{ book.table_of_content|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.table_of_content|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.contents_table_notes|clean_value %}
         <dt class="col-sm-4">Table of contents notes</dt>
-        <dd class="col-sm-8">{{ book.contents_table_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.contents_table_notes|clean_value }}</dd>
     {% endif %}
     {% if book.preface|clean_value %}
         <dt class="col-sm-4">Preface</dt>
-        <dd class="col-sm-8">{{ book.preface|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.preface|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.epilogue|clean_value %}
         <dt class="col-sm-4">Epilogue</dt>
-        <dd class="col-sm-8">{{ book.epilogue|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.epilogue|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.epilogue_notes|clean_value %}
         <dt class="col-sm-4">Epilogue notes</dt>
-        <dd class="col-sm-8">{{ book.epilogue_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.epilogue_notes|clean_value }}</dd>
     {% endif %}
     {% if book.dedications|clean_value %}
         <dt class="col-sm-4">Dedications</dt>
-        <dd class="col-sm-8">{{ book.dedications|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.dedications|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.dedications_notes|clean_value %}
         <dt class="col-sm-4">Dedications notes</dt>
-        <dd class="col-sm-8">{{ book.dedications_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.dedications_notes|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/editions.html
+++ b/haskala/templates/books/_sections/editions.html
@@ -16,66 +16,66 @@
 <dl class="row mb-0">
     {% if book.total_number_of_editions|clean_value %}
         <dt class="col-sm-4">Total number of editions</dt>
-        <dd class="col-sm-8">{{ book.total_number_of_editions|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.total_number_of_editions|clean_value }}</dd>
     {% endif %}
     {% if book.last_known_edition|clean_value %}
         <dt class="col-sm-4">Last known edition</dt>
-        <dd class="col-sm-8">{{ book.last_known_edition|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.last_known_edition|clean_value }}</dd>
     {% endif %}
     {% if book.editions_notes|clean_value %}
         <dt class="col-sm-4">Editions notes</dt>
-        <dd class="col-sm-8">{{ book.editions_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.editions_notes|clean_value }}</dd>
     {% endif %}
     {% if book.references_for_editions|clean_value %}
         <dt class="col-sm-4">References for editions</dt>
-        <dd class="col-sm-8">{{ book.references_for_editions|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.references_for_editions|clean_value }}</dd>
     {% endif %}
     {% if book.new_edition_general_notes|clean_value %}
         <dt class="col-sm-4">New edition notes</dt>
-        <dd class="col-sm-8">{{ book.new_edition_general_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.new_edition_general_notes|clean_value }}</dd>
     {% endif %}
     {% if book.new_edition_type_in_text|clean_value %}
         <dt class="col-sm-4">New edition type (in book)</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_in_text|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.new_edition_type_in_text|clean_value }}</dd>
     {% endif %}
     {% if book.new_edition_type_elsewhere|clean_value %}
         <dt class="col-sm-4">New edition type (elsewhere)</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_elsewhere|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.new_edition_type_elsewhere|clean_value }}</dd>
     {% endif %}
     {% if book.new_edition_type_reference|clean_value %}
         <dt class="col-sm-4">New edition type reference</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_reference|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.new_edition_type_reference|clean_value }}</dd>
     {% endif %}
     {% if book.new_edition_type_else_ref|clean_value %}
         <dt class="col-sm-4">New edition type (other reference)</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_else_ref|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.new_edition_type_else_ref|clean_value }}</dd>
     {% endif %}
     {% if book.new_edition_type_notes|clean_value %}
         <dt class="col-sm-4">New edition type notes</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.new_edition_type_notes|clean_value }}</dd>
     {% endif %}
     {% if book.new_edition_type_else_note|clean_value %}
         <dt class="col-sm-4">New edition type (other notes)</dt>
-        <dd class="col-sm-8">{{ book.new_edition_type_else_note|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.new_edition_type_else_note|clean_value }}</dd>
     {% endif %}
     {% if book.copy_of_book_used|clean_value %}
         <dt class="col-sm-4">Copy of book used</dt>
-        <dd class="col-sm-8">{{ book.copy_of_book_used|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.copy_of_book_used|clean_value }}</dd>
     {% endif %}
     {% if book.other_volumes|clean_value %}
         <dt class="col-sm-4">Other volumes</dt>
-        <dd class="col-sm-8">{{ book.other_volumes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.other_volumes|clean_value }}</dd>
     {% endif %}
     {% if book.volumes_notes|clean_value %}
         <dt class="col-sm-4">Volume notes</dt>
-        <dd class="col-sm-8">{{ book.volumes_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.volumes_notes|clean_value }}</dd>
     {% endif %}
     {% if book.volumes_published_number|clean_value %}
         <dt class="col-sm-4">Volumes published</dt>
-        <dd class="col-sm-8">{{ book.volumes_published_number|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.volumes_published_number|clean_value }}</dd>
     {% endif %}
     {% if book.planned_volumes|clean_value %}
         <dt class="col-sm-4">Planned volumes</dt>
-        <dd class="col-sm-8">{{ book.planned_volumes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.planned_volumes|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/identity.html
+++ b/haskala/templates/books/_sections/identity.html
@@ -2,50 +2,50 @@
 <dl class="row mb-0">
     {% if book.full_title|clean_value %}
         <dt class="col-sm-4">Full title</dt>
-        <dd class="col-sm-8">{{ book.full_title|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.full_title|clean_value }}</dd>
     {% endif %}
     {% if book.title_in_latin_characters|clean_value %}
         <dt class="col-sm-4">Title in Latin characters</dt>
-        <dd class="col-sm-8 fst-italic">{{ book.title_in_latin_characters|clean_value }}</dd>
+        <dd class="col-sm-8 fst-italic" dir="auto">{{ book.title_in_latin_characters|clean_value }}</dd>
     {% endif %}
     {% if book.motto|clean_value %}
         <dt class="col-sm-4">Motto</dt>
-        <dd class="col-sm-8">{{ book.motto|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.motto|clean_value }}</dd>
     {% endif %}
     {% if book.old_name_in_book|clean_value %}
         <dt class="col-sm-4">Old name in book</dt>
-        <dd class="col-sm-8">{{ book.old_name_in_book|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.old_name_in_book|clean_value }}</dd>
     {% endif %}
     {% if book.other_books_names|clean_value %}
         <dt class="col-sm-4">Other names of this book</dt>
-        <dd class="col-sm-8">{{ book.other_books_names|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.other_books_names|clean_value }}</dd>
     {% endif %}
     {% if book.original_text_name|clean_value %}
         <dt class="col-sm-4">Original text name</dt>
-        <dd class="col-sm-8">{{ book.original_text_name|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_text_name|clean_value }}</dd>
     {% endif %}
     {% if book.original_title|clean_value %}
         <dt class="col-sm-4">Original title</dt>
-        <dd class="col-sm-8">{{ book.original_title|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_title|clean_value }}</dd>
     {% endif %}
     {% if book.original_title_else_refer|clean_value %}
         <dt class="col-sm-4">Original title (reference)</dt>
-        <dd class="col-sm-8">{{ book.original_title_else_refer|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_title_else_refer|clean_value }}</dd>
     {% endif %}
     {% if book.original_title_elsewhere|clean_value %}
         <dt class="col-sm-4">Original title elsewhere</dt>
-        <dd class="col-sm-8">{{ book.original_title_elsewhere|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_title_elsewhere|clean_value }}</dd>
     {% endif %}
     {% if book.presented_as_original|clean_value %}
         <dt class="col-sm-4">Presented as original</dt>
-        <dd class="col-sm-8">{{ book.presented_as_original|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.presented_as_original|clean_value }}</dd>
     {% endif %}
     {% if book.presented_as_translation|clean_value %}
         <dt class="col-sm-4">Presented as translation</dt>
-        <dd class="col-sm-8">{{ book.presented_as_translation|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.presented_as_translation|clean_value }}</dd>
     {% endif %}
     {% if book.presented_new_edition|clean_value %}
         <dt class="col-sm-4">Presented as new edition</dt>
-        <dd class="col-sm-8">{{ book.presented_new_edition|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.presented_new_edition|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/languages.html
+++ b/haskala/templates/books/_sections/languages.html
@@ -2,31 +2,31 @@
 <dl class="row mb-0">
     {% if book.languages.all %}
         <dt class="col-sm-4">Languages</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% for lang in book.languages.all %}{{ lang.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
     {% if book.original_language|clean_value %}
         <dt class="col-sm-4">Original language</dt>
-        <dd class="col-sm-8">{{ book.original_language.name }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_language.name }}</dd>
     {% endif %}
     {% if book.languages_number|clean_value %}
         <dt class="col-sm-4">Number of languages</dt>
-        <dd class="col-sm-8">{{ book.languages_number.name }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.languages_number.name }}</dd>
     {% endif %}
     {% if book.footnote_languages.all %}
         <dt class="col-sm-4">Footnote languages</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% for lang in book.footnote_languages.all %}{{ lang.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
     {% if book.location_of_footnotes|clean_value %}
         <dt class="col-sm-4">Location of footnotes</dt>
-        <dd class="col-sm-8">{{ book.location_of_footnotes.name }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.location_of_footnotes.name }}</dd>
     {% endif %}
     {% if book.occasional_words_languages.all %}
         <dt class="col-sm-4">Occasional-word languages</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% for lang in book.occasional_words_languages.all %}{{ lang.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}

--- a/haskala/templates/books/_sections/mentions.html
+++ b/haskala/templates/books/_sections/mentions.html
@@ -25,22 +25,22 @@
 <dl class="row mb-0">
     {% if book.mention_general_notes|clean_value %}
         <dt class="col-sm-4">General mention notes</dt>
-        <dd class="col-sm-8">{{ book.mention_general_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.mention_general_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.mentions_in_reviews|clean_value %}
         <dt class="col-sm-4">Mentions in reviews</dt>
-        <dd class="col-sm-8">{{ book.mentions_in_reviews|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.mentions_in_reviews|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.contemporary_disputes|clean_value %}
         <dt class="col-sm-4">Contemporary disputes</dt>
-        <dd class="col-sm-8">{{ book.contemporary_disputes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.contemporary_disputes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.contemporary_references|clean_value %}
         <dt class="col-sm-4">Contemporary references</dt>
-        <dd class="col-sm-8">{{ book.contemporary_references|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.contemporary_references|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.later_references|clean_value %}
         <dt class="col-sm-4">Later references</dt>
-        <dd class="col-sm-8">{{ book.later_references|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.later_references|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/physical.html
+++ b/haskala/templates/books/_sections/physical.html
@@ -2,42 +2,42 @@
 <dl class="row mb-0">
     {% if book.pages_number|clean_value %}
         <dt class="col-sm-4">Pages</dt>
-        <dd class="col-sm-8">{{ book.pages_number|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.pages_number|clean_value }}</dd>
     {% endif %}
     {% if book.height|clean_value %}
         <dt class="col-sm-4">Height</dt>
-        <dd class="col-sm-8">{{ book.height|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.height|clean_value }}</dd>
     {% endif %}
     {% if book.width|clean_value %}
         <dt class="col-sm-4">Width</dt>
-        <dd class="col-sm-8">{{ book.width|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.width|clean_value }}</dd>
     {% endif %}
     {% if book.alignment|clean_value %}
         <dt class="col-sm-4">Alignment</dt>
-        <dd class="col-sm-8">{{ book.alignment.name }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.alignment.name }}</dd>
     {% endif %}
     {% if book.fonts.all %}
         <dt class="col-sm-4">Fonts</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% for f in book.fonts.all %}{{ f.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
     {% if book.typography.all %}
         <dt class="col-sm-4">Typography</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% for t in book.typography.all %}{{ t.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
         </dd>
     {% endif %}
     {% if book.illustrations_diagrams|clean_value %}
         <dt class="col-sm-4">Illustrations / diagrams</dt>
-        <dd class="col-sm-8">{{ book.illustrations_diagrams|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.illustrations_diagrams|clean_value }}</dd>
     {% endif %}
     {% if book.diagrams_notes|clean_value %}
         <dt class="col-sm-4">Diagram notes</dt>
-        <dd class="col-sm-8">{{ book.diagrams_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.diagrams_notes|clean_value }}</dd>
     {% endif %}
     {% if book.diagrams_book_pages|clean_value %}
         <dt class="col-sm-4">Diagram book pages</dt>
-        <dd class="col-sm-8">{{ book.diagrams_book_pages|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.diagrams_book_pages|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/publication.html
+++ b/haskala/templates/books/_sections/publication.html
@@ -2,7 +2,7 @@
 <dl class="row mb-0">
     {% if book.publisher|clean_value %}
         <dt class="col-sm-4">Publisher</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% if book.publisher.slug %}
                 <a href="{% url 'publisher-detail' book.publisher.slug %}">{{ book.publisher.name }}</a>
             {% else %}
@@ -12,7 +12,7 @@
     {% endif %}
     {% if book.original_publisher|clean_value %}
         <dt class="col-sm-4">Original publisher</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% if book.original_publisher.slug %}
                 <a href="{% url 'publisher-detail' book.original_publisher.slug %}">{{ book.original_publisher.name }}</a>
             {% else %}
@@ -22,7 +22,7 @@
     {% endif %}
     {% if book.publication_place|clean_value %}
         <dt class="col-sm-4">Publication place</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             <a href="{% url 'place-detail' book.publication_place.slug %}">
                 {{ book.publication_place.name }}
             </a>
@@ -30,47 +30,47 @@
     {% endif %}
     {% if book.publication_place_other|clean_value %}
         <dt class="col-sm-4">Other publication place</dt>
-        <dd class="col-sm-8">{{ book.publication_place_other.name }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.publication_place_other.name }}</dd>
     {% endif %}
     {% if book.gregorian_year|clean_value %}
         <dt class="col-sm-4">Year (Gregorian)</dt>
-        <dd class="col-sm-8">{{ book.gregorian_year|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.gregorian_year|clean_value }}</dd>
     {% endif %}
     {% if book.year_in_book|clean_value %}
         <dt class="col-sm-4">Year as in book</dt>
-        <dd class="col-sm-8">{{ book.year_in_book|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.year_in_book|clean_value }}</dd>
     {% endif %}
     {% if book.year_in_other|clean_value %}
         <dt class="col-sm-4">Year (other reference)</dt>
-        <dd class="col-sm-8">{{ book.year_in_other|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.year_in_other|clean_value }}</dd>
     {% endif %}
     {% if book.hebrew_year_of_publication|clean_value %}
         <dt class="col-sm-4">Hebrew year of publication</dt>
-        <dd class="col-sm-8">{{ book.hebrew_year_of_publication|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.hebrew_year_of_publication|clean_value }}</dd>
     {% endif %}
     {% if book.hebrew_year_pub_other|clean_value %}
         <dt class="col-sm-4">Hebrew year (other reference)</dt>
-        <dd class="col-sm-8">{{ book.hebrew_year_pub_other|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.hebrew_year_pub_other|clean_value }}</dd>
     {% endif %}
     {% if book.gregorian_year_pub_other|clean_value %}
         <dt class="col-sm-4">Gregorian year (other reference)</dt>
-        <dd class="col-sm-8">{{ book.gregorian_year_pub_other|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.gregorian_year_pub_other|clean_value }}</dd>
     {% endif %}
     {% if book.format_of_publication_date|clean_value %}
         <dt class="col-sm-4">Format of publication date</dt>
-        <dd class="col-sm-8">{{ book.format_of_publication_date.name }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.format_of_publication_date.name }}</dd>
     {% endif %}
     {% if book.partial_publication|clean_value %}
         <dt class="col-sm-4">Partial publication</dt>
-        <dd class="col-sm-8">{{ book.partial_publication|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.partial_publication|clean_value }}</dd>
     {% endif %}
     {% if book.printed_originally|clean_value %}
         <dt class="col-sm-4">Printed originally</dt>
-        <dd class="col-sm-8">{{ book.printed_originally|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.printed_originally|clean_value }}</dd>
     {% endif %}
     {% if book.original_publication_place|clean_value %}
         <dt class="col-sm-4">Original publication place</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             <a href="{% url 'place-detail' book.original_publication_place.slug %}">
                 {{ book.original_publication_place.name }}
             </a>
@@ -78,27 +78,27 @@
     {% endif %}
     {% if book.original_publication_year|clean_value %}
         <dt class="col-sm-4">Original publication year</dt>
-        <dd class="col-sm-8">{{ book.original_publication_year|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_publication_year|clean_value }}</dd>
     {% endif %}
     {% if book.printers|clean_value %}
         <dt class="col-sm-4">Printers</dt>
-        <dd class="col-sm-8">{{ book.printers|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.printers|clean_value }}</dd>
     {% endif %}
     {% if book.printing_press_notes|clean_value %}
         <dt class="col-sm-4">Printing press notes</dt>
-        <dd class="col-sm-8">{{ book.printing_press_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.printing_press_notes|clean_value }}</dd>
     {% endif %}
     {% if book.printing_press_references|clean_value %}
         <dt class="col-sm-4">Printing press references</dt>
-        <dd class="col-sm-8">{{ book.printing_press_references|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.printing_press_references|clean_value }}</dd>
     {% endif %}
     {% if book.production_evidence|clean_value %}
         <dt class="col-sm-4">Production evidence</dt>
-        <dd class="col-sm-8">{{ book.production_evidence|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.production_evidence|clean_value }}</dd>
     {% endif %}
     {% if book.series|clean_value %}
         <dt class="col-sm-4">Series</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% if book.series.slug %}
                 <a href="{% url 'series-detail' book.series.slug %}">{{ book.series.name }}</a>
             {% else %}
@@ -108,6 +108,6 @@
         </dd>
     {% elif book.series_part %}
         <dt class="col-sm-4">Series part</dt>
-        <dd class="col-sm-8">{{ book.series_part|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.series_part|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/sources.html
+++ b/haskala/templates/books/_sections/sources.html
@@ -2,54 +2,54 @@
 <dl class="row mb-0">
     {% if book.bibliographical_citations|clean_value %}
         <dt class="col-sm-4">Bibliographical citations</dt>
-        <dd class="col-sm-8">{{ book.bibliographical_citations|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.bibliographical_citations|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.studies|clean_value %}
         <dt class="col-sm-4">Studies</dt>
-        <dd class="col-sm-8">{{ book.studies|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.studies|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.sources_exist|clean_value %}
         <dt class="col-sm-4">Sources exist</dt>
-        <dd class="col-sm-8">{{ book.sources_exist|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.sources_exist|clean_value }}</dd>
     {% endif %}
     {% if book.sources_list|clean_value %}
         <dt class="col-sm-4">Sources</dt>
-        <dd class="col-sm-8">{{ book.sources_list|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.sources_list|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.sources_not_mentioned|clean_value %}
         <dt class="col-sm-4">Sources not mentioned in book</dt>
-        <dd class="col-sm-8">{{ book.sources_not_mentioned|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.sources_not_mentioned|clean_value }}</dd>
     {% endif %}
     {% if book.sources_not_mentioned_list|clean_value %}
         <dt class="col-sm-4">Sources not mentioned (list)</dt>
-        <dd class="col-sm-8">{{ book.sources_not_mentioned_list|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.sources_not_mentioned_list|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.sources_not_mentioned_ref|clean_value %}
         <dt class="col-sm-4">Sources not mentioned (reference)</dt>
-        <dd class="col-sm-8">{{ book.sources_not_mentioned_ref|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.sources_not_mentioned_ref|clean_value }}</dd>
     {% endif %}
     {% if book.sources_references|clean_value %}
         <dt class="col-sm-4">Source references</dt>
-        <dd class="col-sm-8">{{ book.sources_references|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.sources_references|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.jewish_sources_quotes|clean_value %}
         <dt class="col-sm-4">Quotes from Jewish sources</dt>
-        <dd class="col-sm-8">{{ book.jewish_sources_quotes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.jewish_sources_quotes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.non_jewish_sources_quotes|clean_value %}
         <dt class="col-sm-4">Quotes from non-Jewish sources</dt>
-        <dd class="col-sm-8">{{ book.non_jewish_sources_quotes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.non_jewish_sources_quotes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.original_sources_mention|clean_value %}
         <dt class="col-sm-4">Original source mention</dt>
-        <dd class="col-sm-8">{{ book.original_sources_mention|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.original_sources_mention|clean_value }}</dd>
     {% endif %}
     {% if book.references_notes|clean_value %}
         <dt class="col-sm-4">References notes</dt>
-        <dd class="col-sm-8">{{ book.references_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.references_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.secondary_sources|clean_value %}
         <dt class="col-sm-4">Secondary sources</dt>
-        <dd class="col-sm-8">{{ book.secondary_sources|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.secondary_sources|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/subscription.html
+++ b/haskala/templates/books/_sections/subscription.html
@@ -2,62 +2,62 @@
 <dl class="row mb-0">
     {% if book.subscribers|clean_value %}
         <dt class="col-sm-4">Subscribers</dt>
-        <dd class="col-sm-8">{{ book.subscribers|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.subscribers|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.subscribers_notes|clean_value %}
         <dt class="col-sm-4">Subscribers notes</dt>
-        <dd class="col-sm-8">{{ book.subscribers_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.subscribers_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.subscription_appeal|clean_value %}
         <dt class="col-sm-4">Subscription appeal</dt>
-        <dd class="col-sm-8">{{ book.subscription_appeal|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.subscription_appeal|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.subscription_appeal_notes|clean_value %}
         <dt class="col-sm-4">Subscription appeal notes</dt>
-        <dd class="col-sm-8">{{ book.subscription_appeal_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.subscription_appeal_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.recommendations|clean_value %}
         <dt class="col-sm-4">Recommendations</dt>
-        <dd class="col-sm-8">{{ book.recommendations|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.recommendations|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.recommendations_notes|clean_value %}
         <dt class="col-sm-4">Recommendation notes</dt>
-        <dd class="col-sm-8">{{ book.recommendations_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.recommendations_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.price|clean_value %}
         <dt class="col-sm-4">Price</dt>
-        <dd class="col-sm-8">{{ book.price|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.price|clean_value }}</dd>
     {% endif %}
     {% if book.sellers|clean_value %}
         <dt class="col-sm-4">Sellers</dt>
-        <dd class="col-sm-8">{{ book.sellers|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.sellers|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.sellers_notes|clean_value %}
         <dt class="col-sm-4">Seller notes</dt>
-        <dd class="col-sm-8">{{ book.sellers_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.sellers_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.thanks|clean_value %}
         <dt class="col-sm-4">Thanks</dt>
-        <dd class="col-sm-8">{{ book.thanks|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.thanks|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.thanks_notes|clean_value %}
         <dt class="col-sm-4">Thanks notes</dt>
-        <dd class="col-sm-8">{{ book.thanks_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.thanks_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.contacts_official_agents|clean_value %}
         <dt class="col-sm-4">Official agents</dt>
-        <dd class="col-sm-8">{{ book.contacts_official_agents|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.contacts_official_agents|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.contacts_other_people|clean_value %}
         <dt class="col-sm-4">Other contacts</dt>
-        <dd class="col-sm-8">{{ book.contacts_other_people|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.contacts_other_people|clean_value|linebreaksbr }}</dd>
     {% endif %}
     {% if book.personal_address|clean_value %}
         <dt class="col-sm-4">Personal address</dt>
-        <dd class="col-sm-8">{{ book.personal_address|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.personal_address|clean_value }}</dd>
     {% endif %}
     {% if book.personal_address_notes|clean_value %}
         <dt class="col-sm-4">Personal address notes</dt>
-        <dd class="col-sm-8">{{ book.personal_address_notes|clean_value|linebreaksbr }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.personal_address_notes|clean_value|linebreaksbr }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/books/_sections/translations.html
+++ b/haskala/templates/books/_sections/translations.html
@@ -22,18 +22,18 @@
 <dl class="row mb-0">
     {% if book.translation_type|clean_value %}
         <dt class="col-sm-4">Translation type</dt>
-        <dd class="col-sm-8">{{ book.translation_type.name }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.translation_type.name }}</dd>
     {% endif %}
     {% if book.translation_notes|clean_value %}
         <dt class="col-sm-4">Translation notes</dt>
-        <dd class="col-sm-8">{{ book.translation_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.translation_notes|clean_value }}</dd>
     {% endif %}
     {% if book.presented_as_translation_refe|clean_value %}
         <dt class="col-sm-4">Presented as translation (reference)</dt>
-        <dd class="col-sm-8">{{ book.presented_as_translation_refe|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.presented_as_translation_refe|clean_value }}</dd>
     {% endif %}
     {% if book.presented_as_translatio_notes|clean_value %}
         <dt class="col-sm-4">Presented as translation (notes)</dt>
-        <dd class="col-sm-8">{{ book.presented_as_translatio_notes|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ book.presented_as_translatio_notes|clean_value }}</dd>
     {% endif %}
 </dl>

--- a/haskala/templates/persons/_sections/biographical.html
+++ b/haskala/templates/persons/_sections/biographical.html
@@ -2,11 +2,11 @@
 <dl class="row mb-0">
     {% if person.date_of_birth|clean_value %}
         <dt class="col-sm-4">Date of birth</dt>
-        <dd class="col-sm-8">{{ person.date_of_birth|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ person.date_of_birth|clean_value }}</dd>
     {% endif %}
     {% if person.place_of_birth|clean_value %}
         <dt class="col-sm-4">Place of birth</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             <a href="{% url 'place-detail' person.place_of_birth.slug %}">
                 {{ person.place_of_birth.name }}
             </a>
@@ -14,11 +14,11 @@
     {% endif %}
     {% if person.date_of_death|clean_value %}
         <dt class="col-sm-4">Date of death</dt>
-        <dd class="col-sm-8">{{ person.date_of_death|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ person.date_of_death|clean_value }}</dd>
     {% endif %}
     {% if person.place_of_death|clean_value %}
         <dt class="col-sm-4">Place of death</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             <a href="{% url 'place-detail' person.place_of_death.slug %}">
                 {{ person.place_of_death.name }}
             </a>

--- a/haskala/templates/persons/_sections/identifiers.html
+++ b/haskala/templates/persons/_sections/identifiers.html
@@ -2,7 +2,7 @@
 <dl class="row mb-0">
     {% if person.viaf_id|clean_value %}
         <dt class="col-sm-4">VIAF</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             <a href="https://viaf.org/viaf/{{ person.viaf_id|clean_value }}/" target="_blank" rel="noopener">
                 {{ person.viaf_id|clean_value }}
             </a>
@@ -10,7 +10,7 @@
     {% endif %}
     {% if person.gnd_id|clean_value %}
         <dt class="col-sm-4">GND</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             <a href="https://d-nb.info/gnd/{{ person.gnd_id|clean_value }}" target="_blank" rel="noopener">
                 {{ person.gnd_id|clean_value }}
             </a>

--- a/haskala/templates/persons/_sections/identity.html
+++ b/haskala/templates/persons/_sections/identity.html
@@ -2,27 +2,27 @@
 <dl class="row mb-0">
     {% if person.pref_label|clean_value %}
         <dt class="col-sm-4">Preferred label</dt>
-        <dd class="col-sm-8">{{ person.pref_label|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ person.pref_label|clean_value }}</dd>
     {% endif %}
     {% if person.german_name|clean_value %}
         <dt class="col-sm-4">German name</dt>
-        <dd class="col-sm-8">{{ person.german_name|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ person.german_name|clean_value }}</dd>
     {% endif %}
     {% if person.hebrew_name|clean_value %}
         <dt class="col-sm-4">Hebrew name</dt>
-        <dd class="col-sm-8" lang="he">{{ person.hebrew_name|clean_value }}</dd>
+        <dd class="col-sm-8" lang="he" dir="auto">{{ person.hebrew_name|clean_value }}</dd>
     {% endif %}
     {% if person.pseudonym|clean_value %}
         <dt class="col-sm-4">Pseudonym</dt>
-        <dd class="col-sm-8">{{ person.pseudonym|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ person.pseudonym|clean_value }}</dd>
     {% endif %}
     {% if person.gender|clean_value %}
         <dt class="col-sm-4">Gender</dt>
-        <dd class="col-sm-8">{{ person.gender|clean_value }}</dd>
+        <dd class="col-sm-8" dir="auto">{{ person.gender|clean_value }}</dd>
     {% endif %}
     {% if person.occupations.all %}
         <dt class="col-sm-4">Occupations</dt>
-        <dd class="col-sm-8">
+        <dd class="col-sm-8" dir="auto">
             {% for occ in person.occupations.all %}
                 <a href="{% url 'occupation-detail' occ.name|slugify %}">{{ occ.name }}</a>{% if not forloop.last %}, {% endif %}
             {% endfor %}


### PR DESCRIPTION
The CSS-only `unicode-bidi: plaintext` from PR #87 wasn't reliably right-aligning Hebrew dd cells on Person pages. Adding `dir="auto"` to every `<dd>` in the 16 section partials gets the browser to derive direction per cell. Pure-Hebrew → right-aligned, Latin/mixed → left-aligned.