### PR TITLE
style(rtl): dir=auto on every section list-item

### DIFF
--- a/haskala/templates/books/_sections/authors.html
+++ b/haskala/templates/books/_sections/authors.html
@@ -4,7 +4,7 @@
     <ul class="list-unstyled mb-3">
         {% for ba in book.bookauthor_set.all %}
             {% if ba.person %}
-                <li class="mb-1">
+                <li class="mb-1" dir="auto">
                     <a href="{% url 'person-detail' ba.person.slug %}" class="link-primary">
                         {{ ba.person }}
                     </a>

--- a/haskala/templates/books/_sections/editions.html
+++ b/haskala/templates/books/_sections/editions.html
@@ -3,7 +3,7 @@
     <h3 class="h6 mt-3">Known editions</h3>
     <ul class="list-unstyled mb-3">
         {% for ed in book.editions.all %}
-            <li class="mb-1">
+            <li class="mb-1" dir="auto">
                 {{ ed.name|default:"[unnamed edition]" }}
                 {% if ed.year %}<span class="text-muted small">&middot; {{ ed.year }}</span>{% endif %}
                 {% if ed.city %}<span class="text-muted small">&middot; {{ ed.city.name }}</span>{% endif %}

--- a/haskala/templates/books/_sections/mentions.html
+++ b/haskala/templates/books/_sections/mentions.html
@@ -2,7 +2,7 @@
 {% if book.mentions.all %}
     <ul class="list-unstyled mb-3">
         {% for m in book.mentions.all %}
-            <li class="mb-2">
+            <li class="mb-2" dir="auto">
                 {% if m.mentionee %}
                     <a href="{% url 'person-detail' m.mentionee.slug %}" class="link-primary">{{ m.mentionee }}</a>
                 {% else %}

--- a/haskala/templates/books/_sections/prefaces.html
+++ b/haskala/templates/books/_sections/prefaces.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for pf in book.prefaces.all %}
-        <li class="mb-2">
+        <li class="mb-2" dir="auto">
             <strong>{{ pf.title|default:"Preface" }}</strong>
             {% if pf.number %}
                 <span class="text-muted small">&middot; #{{ pf.number }}</span>

--- a/haskala/templates/books/_sections/productions.html
+++ b/haskala/templates/books/_sections/productions.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for prod in book.productions.all %}
-        <li class="mb-2">
+        <li class="mb-2" dir="auto">
             {% if prod.producer %}
                 <a href="{% url 'person-detail' prod.producer.slug %}" class="link-primary">
                     {{ prod.producer }}

--- a/haskala/templates/books/_sections/translations.html
+++ b/haskala/templates/books/_sections/translations.html
@@ -3,7 +3,7 @@
     <h3 class="h6 mt-3">Known translations</h3>
     <ul class="list-unstyled mb-3">
         {% for tr in book.translations.all %}
-            <li class="mb-1">
+            <li class="mb-1" dir="auto">
                 {% if tr.translator %}
                     <a href="{% url 'person-detail' tr.translator.slug %}" class="link-primary">
                         {{ tr.translator }}

--- a/haskala/templates/persons/_sections/mentions.html
+++ b/haskala/templates/persons/_sections/mentions.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for m in mentions_of_person %}
-        <li class="mb-2">
+        <li class="mb-2" dir="auto">
             {% if m.mentionee_description %}
                 <strong>{{ m.mentionee_description.name }}</strong>
             {% else %}

--- a/haskala/templates/persons/_sections/prefaces.html
+++ b/haskala/templates/persons/_sections/prefaces.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for preface in prefaces_by_person %}
-        <li class="mb-2">
+        <li class="mb-2" dir="auto">
             {% if preface.title %}
                 <strong>{{ preface.title }}</strong>
                 {% if preface.book %} &mdash; {% endif %}

--- a/haskala/templates/persons/_sections/productions.html
+++ b/haskala/templates/persons/_sections/productions.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for prod in productions_by_person %}
-        <li class="mb-2">
+        <li class="mb-2" dir="auto">
             {% if prod.book %}
                 <a href="{% url 'book-detail' prod.book.slug %}" class="link-primary">
                     {{ prod.book.full_title|default:prod.book.name|default:"[untitled book]" }}

--- a/haskala/templates/persons/_sections/works.html
+++ b/haskala/templates/persons/_sections/works.html
@@ -5,7 +5,7 @@
     </h3>
     <ul class="list-unstyled mb-3">
         {% for book in books %}
-            <li>
+            <li dir="auto">
                 <a href="{% url 'book-detail' book.slug %}" class="link-primary">
                     {{ book.full_title|default:book.name|default:"[untitled]" }}
                 </a>

--- a/haskala/templates/places/_sections/books_published.html
+++ b/haskala/templates/places/_sections/books_published.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for book in books_published_here %}
-        <li class="mb-1">
+        <li class="mb-1" dir="auto">
             <a href="{% url 'book-detail' book.slug %}" class="link-primary">
                 {{ book.full_title|default:book.name|default:"[untitled]" }}
             </a>

--- a/haskala/templates/places/_sections/editions.html
+++ b/haskala/templates/places/_sections/editions.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for ed in editions_here %}
-        <li class="mb-1">
+        <li class="mb-1" dir="auto">
             {% if ed.book %}
                 <a href="{% url 'book-detail' ed.book.slug %}" class="link-primary">
                     {{ ed.book.full_title|default:ed.book.name|default:"[untitled]" }}

--- a/haskala/templates/places/_sections/mentions.html
+++ b/haskala/templates/places/_sections/mentions.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for m in mentions_here %}
-        <li class="mb-2">
+        <li class="mb-2" dir="auto">
             {% if m.mentionee %}
                 <a href="{% url 'person-detail' m.mentionee.slug %}" class="link-primary">
                     {{ m.mentionee }}

--- a/haskala/templates/places/_sections/persons_born.html
+++ b/haskala/templates/places/_sections/persons_born.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for person in born_here %}
-        <li class="mb-1">
+        <li class="mb-1" dir="auto">
             <a href="{% url 'person-detail' person.slug %}" class="link-primary">
                 {{ person }}
             </a>

--- a/haskala/templates/places/_sections/persons_died.html
+++ b/haskala/templates/places/_sections/persons_died.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for person in died_here %}
-        <li class="mb-1">
+        <li class="mb-1" dir="auto">
             <a href="{% url 'person-detail' person.slug %}" class="link-primary">
                 {{ person }}
             </a>

--- a/haskala/templates/places/_sections/translations.html
+++ b/haskala/templates/places/_sections/translations.html
@@ -1,7 +1,7 @@
 {% load value_filters %}
 <ul class="list-unstyled mb-0">
     {% for tr in translations_here %}
-        <li class="mb-1">
+        <li class="mb-1" dir="auto">
             {% if tr.book %}
                 <a href="{% url 'book-detail' tr.book.slug %}" class="link-primary">
                     {{ tr.book.full_title|default:tr.book.name|default:"[untitled]" }}


### PR DESCRIPTION
Mirror of PR #88 for `<li>` elements. PR #88 fixed Hebrew-flow on the dl-row `<dd>` cells; the same issue still applied to the `<ul><li>` lists in persons (works/mentions/prefaces/productions), places (born/died/editions/translations/books_published/mentions) and books sections. Every `<li>` in a section partial now gets `dir="auto"` so the browser picks direction per row.