### PR TITLE
style: wrapper 1080 px + dt body colour

### DIFF
--- a/haskala/static/scss/_book_detail.scss
+++ b/haskala/static/scss/_book_detail.scss
@@ -167,7 +167,10 @@
       min-width: 0;
     }
     dt {
-      color: var(--bs-secondary-color);
+      // Inherits body colour (--bs-body-color, i.e. $haskala-base);
+      // the previous secondary-color was too muted against the
+      // already-muted theme.
+      color: inherit;
       font-weight: 500;
       font-size: 0.92rem;
     }

--- a/haskala/static/scss/_variables.scss
+++ b/haskala/static/scss/_variables.scss
@@ -148,14 +148,7 @@ $card-border-color: $border-color;
 // Wider wrapper so the catalog detail pages don't squeeze rich
 // definition lists into a narrow column on desktop. Legal pages
 // get their own narrow wrapper via .container--narrow below.
-// Catalog detail pages (Books, Persons, Places) have dl-row pairs
-// with long German titles + Hebrew strings; squeezing them into
-// 1280px on a desktop pushed too many lines onto multi-row wraps.
-// 1480px gives an extra ~200px of horizontal breathing room without
-// drifting into "line too long to read" territory (the dd column at
-// 1:2 grid lands around 950px — still well below the 80-character
-// readability cap with the 16px base font).
-$wrapper-max-width: 1480px;
+$wrapper-max-width: 1080px;
 $wrapper-narrow-max-width: 760px;
 $site-padding-x:    24px;
 


### PR DESCRIPTION
Two follow-ups:

- Wrapper max-width back to 1080 px (was 1480). 1480 felt too wide.
- `dl-row dt` color: inherits body `$haskala-base` instead of `--bs-secondary-color`. The previous muted grey was too washed-out against the already muted theme.