### PR TITLE
style(menu): center wrapped main-menu items on mobile

### DIFF
--- a/haskala/templates/partials/mainmenu.html
+++ b/haskala/templates/partials/mainmenu.html
@@ -3,7 +3,7 @@
 
 <header>
     <nav class="top-navigation nav-bar top-menu d-flex justify-content-center">
-        <ul class="menu nav">
+        <ul class="menu nav justify-content-center flex-wrap">
             <li class="first leaf"><a href="{% url 'books-list' %}" title="">BOOKS</a></li>
             <li class="leaf"><a href="{% url 'digital-books-list' %}" title="">DIGITAL BOOKS</a></li>
             <li class="leaf"><a href="{% url 'persons-list' %}" title="">PERSONS</a></li>


### PR DESCRIPTION
On narrow viewports the main-menu items wrap to multiple rows; the wrapped rows sat flush-left because the inner `<ul class="menu nav">` had no `justify-content` rule. Add `.justify-content-center.flex-wrap` to the ul so every row centers.