### PR TITLE
style(menu): drop top-nav dot separators on mobile

### DIFF
--- a/haskala/static/scss/_menu.scss
+++ b/haskala/static/scss/_menu.scss
@@ -38,6 +38,16 @@
           content: none;
         }
 
+        // Mobile: drop the dot separators. With items wrapping to
+        // multiple rows, dots at line-start read as stray punctuation
+        // rather than as separators.
+        @media (max-width: 767.98px) {
+          &:before {
+            content: none;
+            margin-right: 0;
+          }
+        }
+
         &:first-child {
           margin-left: 0;
         }


### PR DESCRIPTION
The desktop top-nav uses `.` dots between items as separators. On mobile the items wrap to multiple rows and the dots show up at the start of every wrapped line, looking like stray punctuation. Suppress them below the `md` breakpoint.