### PR TITLE
feat(menu): mobile hamburger offcanvas + sticky top bar

### DIFF
--- a/haskala/static/scss/_menu.scss
+++ b/haskala/static/scss/_menu.scss
@@ -2,6 +2,68 @@
 // MAIN MENU (Top Navigation)
 // =====================================
 
+// Sticky top bar that wraps the desktop nav + mobile hamburger.
+// Bootstrap's .sticky-top sets position: sticky / top: 0 / z-index;
+// the extra rules below give the bar a white opaque background so
+// scrolling content doesn't bleed through.
+.site-topbar {
+  background: $body-bg;
+  padding: 0.25rem 0;
+  // Shadow only kicks in once the bar is actually stuck (visually
+  // separates it from the page hero scrolling behind).
+  box-shadow: 0 1px 0 var(--bs-border-color);
+  // Flex so the desktop nav stays centered AND the mobile hamburger
+  // can push itself to the right edge via margin-left: auto.
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.site-topbar__toggle {
+  font-size: 1.6rem;
+  padding: 0.25rem 0.5rem;
+  color: $haskala-base;
+  // Right edge of the bar on mobile (where this button is the only
+  // visible child of the flex .site-topbar).
+  margin-left: auto;
+  // No fill — the icon sits flat on the page.
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+
+  &:hover,
+  &:focus {
+    background: transparent !important;
+    color: $haskala-blue;
+  }
+}
+
+// Mobile offcanvas nav — vertical list of links, large hit areas
+// so taps don't miss on small phones.
+.mobile-nav-list {
+  margin: 0;
+  padding: 0;
+
+  li + li {
+    border-top: 1px solid var(--bs-border-color);
+  }
+
+  a {
+    display: block;
+    padding: 0.75rem 0.25rem;
+    color: $haskala-base;
+    font-family: $headings-font-family;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      color: $haskala-blue;
+    }
+  }
+}
+
 .wrapper {
   header {
     // Links im Header

--- a/haskala/templates/partials/mainmenu.html
+++ b/haskala/templates/partials/mainmenu.html
@@ -2,21 +2,49 @@
 
 
 <header>
-    <nav class="top-navigation nav-bar top-menu d-flex justify-content-center">
-        <ul class="menu nav justify-content-center flex-wrap">
-            <li class="first leaf"><a href="{% url 'books-list' %}" title="">BOOKS</a></li>
-            <li class="leaf"><a href="{% url 'digital-books-list' %}" title="">DIGITAL BOOKS</a></li>
-            <li class="leaf"><a href="{% url 'persons-list' %}" title="">PERSONS</a></li>
-            <li class="leaf"><a href="{% url 'places-list' %}" title="">PLACES</a></li>
-            <li class="last leaf">
-                <a href="{% url 'search' %}" title="">
-                    SEARCH <i class="bi bi-search"></i>
-                </a>
-            </li>
-        </ul>
-    </nav>
+    <div class="site-topbar sticky-top">
+        <button type="button"
+                class="btn site-topbar__toggle d-md-none"
+                data-bs-toggle="offcanvas"
+                data-bs-target="#mobileNav"
+                aria-controls="mobileNav"
+                aria-label="Open menu">
+            <i class="bi bi-list"></i>
+        </button>
+
+        <nav class="top-navigation nav-bar top-menu d-none d-md-flex justify-content-center">
+            <ul class="menu nav justify-content-center flex-wrap">
+                <li class="first leaf"><a href="{% url 'books-list' %}" title="">BOOKS</a></li>
+                <li class="leaf"><a href="{% url 'digital-books-list' %}" title="">DIGITAL BOOKS</a></li>
+                <li class="leaf"><a href="{% url 'persons-list' %}" title="">PERSONS</a></li>
+                <li class="leaf"><a href="{% url 'places-list' %}" title="">PLACES</a></li>
+                <li class="last leaf">
+                    <a href="{% url 'search' %}" title="">
+                        SEARCH <i class="bi bi-search"></i>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    </div>
+
     <h1 class="site-name"><a href="/" title="Home"
                              class="link-underline-opacity-0 link-underline-opacity-0-hover"><span>Library of the</span>
         Haskala</a></h1>
     <hr>
 </header>
+
+<div class="offcanvas offcanvas-end" tabindex="-1" id="mobileNav" aria-labelledby="mobileNavLabel">
+    <div class="offcanvas-header">
+        <h2 class="offcanvas-title h5" id="mobileNavLabel">Menu</h2>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+        <ul class="list-unstyled mobile-nav-list">
+            <li><a href="{% url 'books-list' %}">Books</a></li>
+            <li><a href="{% url 'digital-books-list' %}">Digital Books</a></li>
+            <li><a href="{% url 'persons-list' %}">Persons</a></li>
+            <li><a href="{% url 'places-list' %}">Places</a></li>
+            <li><a href="{% url 'search' %}"><i class="bi bi-search"></i> Search</a></li>
+        </ul>
+    </div>
+</div>


### PR DESCRIPTION
Two related menu improvements:

- **Sticky top bar** (`position: sticky; top: 0` via Bootstrap's `.sticky-top`) — the menu stays on the viewport edge while the page scrolls.
- **Hamburger + offcanvas on mobile** (`d-md-none` toggle button + Bootstrap `.offcanvas-end` panel) — below md the desktop nav is hidden and the hamburger reveals the menu as a vertical list sliding in from the right. Same five routes; large tap targets; Bell-headline-font labels.

## Test plan
- [x] manage.py test 42/42
- [x] /  rendered HTML carries `.site-topbar.sticky-top`, `.site-topbar__toggle.d-md-none`, `#mobileNav.offcanvas.offcanvas-end`
- [x] Bootstrap bundle (offcanvas JS) already loaded via `app.js` entry