### PR TITLE
style(menu): transparent topbar + aria-label on offcanvas

### DIFF
--- a/haskala/static/scss/_menu.scss
+++ b/haskala/static/scss/_menu.scss
@@ -7,11 +7,9 @@
 // the extra rules below give the bar a white opaque background so
 // scrolling content doesn't bleed through.
 .site-topbar {
-  background: $body-bg;
   padding: 0.25rem 0;
   // Shadow only kicks in once the bar is actually stuck (visually
   // separates it from the page hero scrolling behind).
-  box-shadow: 0 1px 0 var(--bs-border-color);
   // Flex so the desktop nav stays centered AND the mobile hamburger
   // can push itself to the right edge via margin-left: auto.
   display: flex;

--- a/haskala/templates/partials/mainmenu.html
+++ b/haskala/templates/partials/mainmenu.html
@@ -33,9 +33,8 @@
     <hr>
 </header>
 
-<div class="offcanvas offcanvas-end" tabindex="-1" id="mobileNav" aria-labelledby="mobileNavLabel">
+<div class="offcanvas offcanvas-end" tabindex="-1" id="mobileNav" aria-label="Menu">
     <div class="offcanvas-header">
-        <h2 class="offcanvas-title h5" id="mobileNavLabel">Menu</h2>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <div class="offcanvas-body">


### PR DESCRIPTION
Two small follow-ups on the new sticky menu (PR #96):

- `.site-topbar` drops the opaque background + the bottom border-shadow so the bar blends into the page header.
- Replace dangling `aria-labelledby="mobileNavLabel"` on the offcanvas with `aria-label="Menu"` since the user removed the `<h2 id="mobileNavLabel">` heading earlier.