### PR TITLE
fix(places): use city.slug for detail links + drop digital_book_attributes

### DIFF
--- a/haskala/templates/books/_sections/availability.html
+++ b/haskala/templates/books/_sections/availability.html
@@ -16,9 +16,6 @@
                 {{ book.digital_book_title|default:"Open digital copy" }}
                 <i class="bi bi-box-arrow-up-right small"></i>
             </a>
-            {% if book.digital_book_attributes|clean_value %}
-                <div class="small text-muted">{{ book.digital_book_attributes|clean_value }}</div>
-            {% endif %}
         </dd>
     {% endif %}
     {% if book.other_libraries|clean_value %}

--- a/haskala/templates/places/places_page.html
+++ b/haskala/templates/places/places_page.html
@@ -33,15 +33,13 @@
                             <ul class="list-unstyled mb-0">
                                 {% for city in cities %}
                                     <li class="mb-1">
-                                        {% with slug=city.name|slugify %}
-                                            {% if slug %}
-                                                <a href="{% url 'place-detail' slug %}" class="link-primary">
-                                                    {{ city.name }}
-                                                </a>
-                                            {% else %}
-                                                <span>{{ city.name }}</span>
-                                            {% endif %}
-                                        {% endwith %}
+                                        {% if city.slug %}
+                                            <a href="{% url 'place-detail' city.slug %}" class="link-primary">
+                                                {{ city.name }}
+                                            </a>
+                                        {% else %}
+                                            <span>{{ city.name }}</span>
+                                        {% endif %}
                                     </li>
                                 {% endfor %}
                             </ul>


### PR DESCRIPTION
Two cleanups bundled:

- **places**: `/places/` was building detail links via `city.name|slugify`. Django's ASCII-only `slugify` returns empty for the 20 cities whose name is pure Hebrew (ולאטאווי, מיץ, אמשניץ, …), so they had no link. Migration 0029 already populated every `City` with `city-<8 uuid>`; switch the template to use `city.slug`.
- **books availability**: drop the `digital_book_attributes` row (noisy legacy values).

Note: Topic and Occupation index pages have the same pattern (`topic.name|slugify`, `occ.name|slugify`) and would fail the same way for Hebrew names — neither model has a slug field yet, so that's a separate follow-up.