### PR TITLE
fix(data): strip Drupal a:0:{} empty arrays

### DIFF
--- a/home/migrations/0031_strip_php_empty_arrays.py
+++ b/home/migrations/0031_strip_php_empty_arrays.py
@@ -1,0 +1,60 @@
+"""
+Empty out every Book TextField/CharField whose value is the PHP-
+serialised empty array (``a:0:{}``) carried over from the Drupal-6
+import. The rendered detail rows used to surface this noise as the
+field value; the value_filters.clean_value filter handles it on the
+display side, but emptying the DB itself keeps the field empty in
+the Wagtail admin too.
+
+The 0030 migration already strips legacy patterns from Person names;
+this one targets the other half of the legacy junk — PHP
+``serialize(array())`` empties — across every Book text column.
+"""
+from __future__ import annotations
+
+import re
+
+from django.db import migrations
+
+
+_PHP_EMPTY_ARRAY = re.compile(r'^a:0:\{\}\s*;?\s*$')
+
+
+def forwards(apps, schema_editor):
+    Book = apps.get_model("home", "Book")
+    text_fields = [
+        f.name for f in Book._meta.fields
+        if f.get_internal_type() in ("TextField", "CharField")
+    ]
+    cleaned = 0
+    for b in Book.objects.all():
+        updates = {}
+        for fname in text_fields:
+            v = getattr(b, fname, None) or ""
+            if _PHP_EMPTY_ARRAY.match(v.strip()):
+                updates[fname] = ""
+        if updates:
+            for fname, new in updates.items():
+                setattr(b, fname, new)
+            b.save(update_fields=list(updates))
+            cleaned += 1
+    if cleaned:
+        print(f"  cleaned a:0:{{}} from {cleaned} Book rows")
+
+
+def revert(apps, schema_editor):
+    # Lossy migration — no way to restore the original "a:0:{}"
+    # string per-row from an empty TextField. No-op so a backwards
+    # migrate doesn't crash.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("home", "0030_clean_person_names"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, reverse_code=revert),
+    ]

--- a/home/templatetags/value_filters.py
+++ b/home/templatetags/value_filters.py
@@ -15,6 +15,8 @@ and inside templates via the registered ``|clean_value`` filter.
 """
 from __future__ import annotations
 
+import re
+
 from django import template
 
 register = template.Library()
@@ -24,6 +26,13 @@ register = template.Library()
 # them. The float and int forms cover any future code that hands the
 # filter a real number.
 _ZEROISH = {"", "0", "0.0", "0.00", "0.000", 0, 0.0, False, None}
+
+# Drupal-6 emitted PHP-serialised empty arrays into TextField columns
+# whenever a multi-value form was left blank. The wire format is
+# ``a:0:{}`` for an empty array and ``a:N:{ … }`` for non-empty. The
+# regex below catches every empty form (``a:0:{}``, ``a:0:{};``) so
+# the rendered detail rows don't surface "a:0:{}" as the field value.
+_PHP_EMPTY_ARRAY = re.compile(r'^a:0:\{\}\s*;?\s*$')
 
 
 def clean_value(value):
@@ -52,6 +61,8 @@ def clean_value(value):
     if isinstance(value, str):
         stripped = value.strip()
         if stripped in _ZEROISH:
+            return ""
+        if _PHP_EMPTY_ARRAY.match(stripped):
             return ""
         try:
             as_float = float(stripped)


### PR DESCRIPTION
Two-layer fix for PHP-serialised empty arrays carried over from the Drupal-6 import:

- `clean_value` filter now recognises `a:0:{}` as empty so any template using `|clean_value` collapses the row.
- New data migration `0031_strip_php_empty_arrays` walks every Book row and clears any TextField/CharField whose value matches the regex. Dev DB: 69 rows cleaned (all in `digital_book_attributes`).

manage.py test 42/42, flake8 clean.