### PR TITLE
feat(export): PDF download via WeasyPrint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-r
     libgdal-dev \
     gdal-bin \
     cron \
+    libpango-1.0-0 \
+    libpangoft2-1.0-0 \
+    libharfbuzz0b \
+    libfontconfig1 \
+    fonts-dejavu \
  && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install --yes --quiet --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/*

--- a/haskala/templates/books/_pdf/book_pdf.html
+++ b/haskala/templates/books/_pdf/book_pdf.html
@@ -1,0 +1,82 @@
+{% load wagtailcore_tags utils value_filters %}<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{ book.full_title|default:book.name }} — Haskala</title>
+<style>
+    @page {
+        size: A4;
+        margin: 2cm 1.8cm;
+        @bottom-right {
+            content: "Haskala Library  •  page " counter(page) " / " counter(pages);
+            font-size: 9pt;
+            color: #595752;
+        }
+    }
+    body {
+        font-family: "DejaVu Sans", "Open Sans", sans-serif;
+        font-size: 10pt;
+        color: #5e5d58;
+        line-height: 1.45;
+    }
+    h1, h2, h3 {
+        color: #0D0D0D;
+        font-family: "DejaVu Serif", serif;
+        page-break-after: avoid;
+    }
+    h1 { font-size: 18pt; margin: 0 0 .2cm; }
+    h1 .latin { display: block; font-size: 11pt; color: #595752; font-weight: 400; font-style: italic; margin-top: .15cm; }
+    h2 { font-size: 13pt; margin: .8cm 0 .3cm; border-bottom: 1px solid #eae9e7; padding-bottom: .1cm; }
+    h3 { font-size: 11pt; margin: .4cm 0 .15cm; }
+    .meta { color: #595752; font-size: 9pt; margin-bottom: .8cm; }
+    /* Section dl rows render as a two-column grid for print. */
+    dl.row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+        column-gap: .5cm;
+        row-gap: .15cm;
+        margin: 0 0 .3cm;
+    }
+    dl dt { color: #5e5d58; font-weight: 600; font-size: 9pt; }
+    dl dd { margin: 0; }
+    /* Auto-bidi support — for elements that carry dir="auto" the
+       browser already picks rtl/ltr per content; this keeps the
+       inline flow consistent inside the cells. */
+    [dir="auto"], [lang="he"] { unicode-bidi: plaintext; overflow-wrap: anywhere; }
+    a { color: #1f6e94; text-decoration: none; }
+    ul { padding-left: 1.2em; margin: 0 0 .3cm; }
+    li { margin-bottom: .1cm; }
+    .small, .text-muted { color: #797972; font-size: 8.5pt; }
+    /* Hide Bootstrap-utility classes that wouldn't make sense in print. */
+    .col-sm-4, .col-sm-8 { display: contents; }
+    .badge, .btn { display: none; }
+    section { break-inside: avoid; margin-bottom: .3cm; }
+    .header-block { border-bottom: 1px solid #eae9e7; padding-bottom: .4cm; margin-bottom: .6cm; }
+</style>
+</head>
+<body>
+
+<div class="header-block">
+    <h1>
+        {{ book.full_title|default:book.name }}
+        {% if book.title_in_latin_characters %}
+            <span class="latin" dir="auto">{{ book.title_in_latin_characters }}</span>
+        {% endif %}
+    </h1>
+    <p class="meta">
+        {% if book.bookauthor_set.all %}{% for ba in book.bookauthor_set.all %}{% if ba.person %}{{ ba.person }}{% if ba.role %} ({{ ba.get_role_display }}){% endif %}{% if not forloop.last %}; {% endif %}{% endif %}{% endfor %} ·{% endif %}
+        {% if book.publication_place %} {{ book.publication_place.name }}{% endif %}
+        {% if book.publisher %}{% if book.publication_place %} · {% endif %}{{ book.publisher.name }}{% endif %}
+        {% if book.gregorian_year or book.year_in_book %}{% if book.publication_place or book.publisher %} · {% endif %}{{ book.gregorian_year|default:book.year_in_book }}{% endif %}
+    </p>
+</div>
+
+{% for section in visible_sections %}
+    <section class="book-section">
+        <h2>{{ section.label }}</h2>
+        {% include "books/_sections/"|add:section.slug|add:".html" %}
+    </section>
+{% endfor %}
+
+</body>
+</html>

--- a/haskala/templates/partials/_export_modal.html
+++ b/haskala/templates/partials/_export_modal.html
@@ -26,6 +26,15 @@ Required context:
         </p>
 
         <div class="list-group">
+          <a href="{% url entity|add:'-export' slug 'pdf' %}"
+             class="list-group-item list-group-item-action d-flex justify-content-between align-items-start">
+            <div>
+              <div class="fw-semibold">PDF</div>
+              <div class="small text-muted">application/pdf &middot; printable record for offline use</div>
+            </div>
+            <span class="badge bg-primary rounded-pill">.pdf</span>
+          </a>
+
           <a href="{% url entity|add:'-export' slug 'ttl' %}"
              class="list-group-item list-group-item-action d-flex justify-content-between align-items-start">
             <div>

--- a/haskala/templates/persons/_pdf/person_pdf.html
+++ b/haskala/templates/persons/_pdf/person_pdf.html
@@ -1,0 +1,56 @@
+{% load wagtailcore_tags utils value_filters %}<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{ person.pref_label|default:person.german_name|default:person.hebrew_name }} — Haskala</title>
+<style>
+    @page {
+        size: A4;
+        margin: 2cm 1.8cm;
+        @bottom-right {
+            content: "Haskala Library  •  page " counter(page) " / " counter(pages);
+            font-size: 9pt;
+            color: #595752;
+        }
+    }
+    body { font-family: "DejaVu Sans", sans-serif; font-size: 10pt; color: #5e5d58; line-height: 1.45; }
+    h1, h2 { color: #0D0D0D; font-family: "DejaVu Serif", serif; page-break-after: avoid; }
+    h1 { font-size: 18pt; margin: 0 0 .2cm; }
+    h2 { font-size: 13pt; margin: .8cm 0 .3cm; border-bottom: 1px solid #eae9e7; padding-bottom: .1cm; }
+    h3 { font-size: 11pt; margin: .4cm 0 .15cm; }
+    .meta { color: #595752; font-size: 9pt; margin-bottom: .8cm; }
+    dl.row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 2fr); column-gap: .5cm; row-gap: .15cm; margin: 0 0 .3cm; }
+    dl dt { color: #5e5d58; font-weight: 600; font-size: 9pt; }
+    dl dd { margin: 0; }
+    [dir="auto"], [lang="he"] { unicode-bidi: plaintext; overflow-wrap: anywhere; }
+    a { color: #1f6e94; text-decoration: none; }
+    ul { padding-left: 1.2em; margin: 0 0 .3cm; }
+    li { margin-bottom: .1cm; }
+    .small, .text-muted { color: #797972; font-size: 8.5pt; }
+    .col-sm-4, .col-sm-8 { display: contents; }
+    .badge, .btn { display: none; }
+    section { break-inside: avoid; margin-bottom: .3cm; }
+    .header-block { border-bottom: 1px solid #eae9e7; padding-bottom: .4cm; margin-bottom: .6cm; }
+</style>
+</head>
+<body>
+
+<div class="header-block">
+    <h1 dir="auto">{{ person.pref_label|default:person.german_name|default:person.hebrew_name }}</h1>
+    <p class="meta">
+        {% if person.date_of_birth %}* {{ person.date_of_birth }}{% endif %}
+        {% if person.place_of_birth %} {{ person.place_of_birth.name }}{% endif %}
+        {% if person.date_of_death %} &nbsp;†&nbsp; {{ person.date_of_death }}{% endif %}
+        {% if person.place_of_death %} {{ person.place_of_death.name }}{% endif %}
+    </p>
+</div>
+
+{% for section in visible_sections %}
+    <section class="person-section">
+        <h2>{{ section.label }}</h2>
+        {% include "persons/_sections/"|add:section.slug|add:".html" %}
+    </section>
+{% endfor %}
+
+</body>
+</html>

--- a/haskala/templates/places/_pdf/place_pdf.html
+++ b/haskala/templates/places/_pdf/place_pdf.html
@@ -1,0 +1,53 @@
+{% load wagtailcore_tags utils value_filters %}<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{ city.name }} — Haskala</title>
+<style>
+    @page {
+        size: A4;
+        margin: 2cm 1.8cm;
+        @bottom-right {
+            content: "Haskala Library  •  page " counter(page) " / " counter(pages);
+            font-size: 9pt;
+            color: #595752;
+        }
+    }
+    body { font-family: "DejaVu Sans", sans-serif; font-size: 10pt; color: #5e5d58; line-height: 1.45; }
+    h1, h2 { color: #0D0D0D; font-family: "DejaVu Serif", serif; page-break-after: avoid; }
+    h1 { font-size: 18pt; margin: 0 0 .2cm; }
+    h2 { font-size: 13pt; margin: .8cm 0 .3cm; border-bottom: 1px solid #eae9e7; padding-bottom: .1cm; }
+    h3 { font-size: 11pt; margin: .4cm 0 .15cm; }
+    .meta { color: #595752; font-size: 9pt; margin-bottom: .8cm; }
+    dl.row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 2fr); column-gap: .5cm; row-gap: .15cm; margin: 0 0 .3cm; }
+    dl dt { color: #5e5d58; font-weight: 600; font-size: 9pt; }
+    dl dd { margin: 0; }
+    [dir="auto"], [lang="he"] { unicode-bidi: plaintext; overflow-wrap: anywhere; }
+    a { color: #1f6e94; text-decoration: none; }
+    ul { padding-left: 1.2em; margin: 0 0 .3cm; }
+    li { margin-bottom: .1cm; }
+    .small, .text-muted { color: #797972; font-size: 8.5pt; }
+    .col-sm-4, .col-sm-8 { display: contents; }
+    .badge, .btn { display: none; }
+    section { break-inside: avoid; margin-bottom: .3cm; }
+    .header-block { border-bottom: 1px solid #eae9e7; padding-bottom: .4cm; margin-bottom: .6cm; }
+</style>
+</head>
+<body>
+
+<div class="header-block">
+    <h1 dir="auto">{{ city.name }}</h1>
+    {% if geolocation %}
+        <p class="meta">{{ geolocation.lat }}, {{ geolocation.lng }}</p>
+    {% endif %}
+</div>
+
+{% for section in visible_sections %}
+    <section class="place-section">
+        <h2>{{ section.label }}</h2>
+        {% include "places/_sections/"|add:section.slug|add:".html" %}
+    </section>
+{% endfor %}
+
+</body>
+</html>

--- a/home/views.py
+++ b/home/views.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from django.db.models import Prefetch, Q
 from django.http import Http404, HttpResponse
 from django.shortcuts import render, get_object_or_404
+from django.template.loader import render_to_string
 from django.utils.text import slugify
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_headers
@@ -992,16 +993,98 @@ def _serialize_entity_response(obj, fmt, *, attachment_basename):
     return response
 
 
+def _pdf_entity_response(request, obj, *, template_name, attachment_basename, context_extra=None):
+    """Render *obj* via *template_name* and return the result as a PDF."""
+    from weasyprint import HTML
+
+    context = {"object": obj, "request": request, **(context_extra or {})}
+    html_string = render_to_string(template_name, context, request=request)
+    base_url = request.build_absolute_uri("/")
+    pdf_bytes = HTML(string=html_string, base_url=base_url).write_pdf()
+    response = HttpResponse(pdf_bytes, content_type="application/pdf")
+    response["Content-Disposition"] = (
+        f'attachment; filename="{attachment_basename}.pdf"'
+    )
+    return response
+
+
 def book_export(request, slug, fmt):
     book = get_object_or_404(Book, slug=slug, live=True)
+    if fmt == "pdf":
+        return _pdf_entity_response(
+            request, book,
+            template_name="books/_pdf/book_pdf.html",
+            attachment_basename=book.slug,
+            context_extra={"book": book, "visible_sections": visible_sections(book)},
+        )
     return _serialize_entity_response(book, fmt, attachment_basename=book.slug)
 
 
 def person_export(request, slug, fmt):
     person = get_object_or_404(Person, slug=slug, live=True)
+    if fmt == "pdf":
+        return _pdf_entity_response(
+            request, person,
+            template_name="persons/_pdf/person_pdf.html",
+            attachment_basename=person.slug,
+            context_extra={"person": person,
+                           "visible_sections": person_visible_sections(person)},
+        )
     return _serialize_entity_response(person, fmt, attachment_basename=person.slug)
 
 
 def place_export(request, slug, fmt):
     city = get_object_or_404(City, slug=slug, live=True)
+    if fmt == "pdf":
+        # Pass the same context the HTML place_detail_view assembles
+        # so the PDF picks up books_published_here / born_here / etc.
+        ctx = _place_context_for_pdf(request, city)
+        return _pdf_entity_response(
+            request, city,
+            template_name="places/_pdf/place_pdf.html",
+            attachment_basename=city.slug,
+            context_extra=ctx,
+        )
     return _serialize_entity_response(city, fmt, attachment_basename=city.slug)
+
+
+def _place_context_for_pdf(request, city):
+    """Reuse the place detail view's context for the PDF render."""
+    geolocation = Geolocation.objects.filter(city=city).first()
+    books_published_here = (
+        Book.objects.filter(live=True)
+        .filter(
+            Q(publication_place=city)
+            | Q(publication_place_other=city)
+            | Q(original_publication_place=city)
+        )
+        .order_by("gregorian_year", "name")
+        .distinct()
+    )
+    editions_here = (
+        Edition.objects.filter(city=city).select_related("book")
+        .order_by("year").distinct()
+    )
+    translations_here = (
+        Translation.objects.filter(city=city).select_related("book", "language")
+        .order_by("year").distinct()
+    )
+    mentions_here = (
+        Mention.objects.filter(mentionee_city=city)
+        .select_related("book", "mentionee", "mentionee_description")
+        .order_by("mentionee__pref_label")
+    )
+    born_here = city.born_here.filter(live=True).order_by("pref_label")
+    died_here = city.died_here.filter(live=True).order_by("pref_label")
+    ctx = {
+        "city": city,
+        "geolocation": geolocation,
+        "books_published_here": books_published_here,
+        "editions_here": editions_here,
+        "translations_here": translations_here,
+        "mentions_here": mentions_here,
+        "born_here": born_here,
+        "died_here": died_here,
+    }
+    ctx["visible_sections"] = place_visible_sections(ctx)
+    return ctx

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ pytz==2026.2
 rdflib==7.6.0
 requests==2.33.0
 djangordf==0.4.1
+weasyprint==69.0
 six==1.17.0
 soupsieve==2.5
 sqlparse==0.5.4


### PR DESCRIPTION
Adds a printable PDF option at the top of the Export modal for Books / Persons / Places. WeasyPrint renders an HTML template (lightweight wrapper + reused `_sections/*.html` partials) to A4 PDF with serif headings, dl-row grid, Hebrew rtl support, page footer.

Verified via curl: `/{books,persons,places}/<slug>/export.pdf` → HTTP 200, `application/pdf`, ~14–22 KB.

requirements.txt pins `weasyprint==69.0`; Dockerfile gets `libpango-1.0-0 libpangoft2-1.0-0 libharfbuzz0b libfontconfig1 fonts-dejavu` so a clean image build has the runtime deps.

manage.py test 42/42, flake8 clean.