### PR TITLE
fix(books): library catalog IDs use search-by-shelfmark URLs

### DIFF
--- a/home/templatetags/utils.py
+++ b/home/templatetags/utils.py
@@ -19,26 +19,36 @@ def slugify(value):
 # in service in 2026 and are the best public links we have today —
 # corrections welcome as systems migrate.
 LIBRARY_CATALOG_URLS = {
+    # All shelf-mark searches go through each library's current public
+    # discovery UI with a CONTAINS query. The legacy templates tried
+    # `any,exact,{id}` against record-by-ID slots; the catalog field
+    # actually holds signatures (e.g. "A02 MAI (MAI)") so exact-match
+    # on the system ID never resolved.
     "bar_ilan": (
         "https://biu.primo.exlibrisgroup.com/discovery/search"
-        "?vid=972BIU_VU1&query=any,exact,{id}"
+        "?query=any,contains,{id}"
+        "&tab=Everything&search_scope=MyInst_and_CI&vid=972BIU_VU1"
     ),
-    "berlin": "https://stabikat.de/Record/{id}",
+    "berlin": "https://stabikat.de/Search/Results?lookfor={id}&type=AllFields",
     "british": (
         "https://bll01.primo.exlibrisgroup.com/discovery/search"
-        "?vid=44BL_INST:BLL01&query=any,exact,{id}"
+        "?query=any,contains,{id}"
+        "&tab=Everything&search_scope=Not_BL_Suppress&vid=44BL_INST:BLL01"
     ),
-    "frankfurt": "https://hds.hebis.de/ubffm/Record/{id}",
+    # Frankfurt mixes URNs (urn:nbn:de:hebis:30-…) with shelf marks;
+    # the URN form is handled in library_catalog_url() below so the
+    # NBN resolver opens the record directly.
+    "frankfurt": "https://hds.hebis.de/ubffm/Search/Results?lookfor={id}&type=AllFields",
     "huji": (
         "https://huji.primo.exlibrisgroup.com/discovery/search"
-        "?vid=972HUJI_MAIN_VU2&query=any,exact,{id}"
+        "?query=any,contains,{id}"
+        "&tab=Everything&search_scope=MyInst_and_CI&vid=972HUJI_MAIN_VU2"
     ),
-    "new_york": (
-        "https://search.library.columbia.edu/catalog?q={id}"
-    ),
+    "new_york": "https://search.library.columbia.edu/catalog?q={id}",
     "tel_aviv": (
         "https://tau-primo.hosted.exlibrisgroup.com/primo-explore/search"
-        "?vid=TAU&query=any,exact,{id}"
+        "?query=any,contains,{id}"
+        "&tab=default_tab&search_scope=default_scope&vid=TAU"
     ),
 }
 
@@ -79,10 +89,24 @@ def library_catalog_url(value, library):
     Returns the URL string, or "" if the library key is unknown or
     the value is empty. Templates can compare the result to "" to
     decide whether to render an anchor or plain text.
+
+    Special-case: Frankfurt rows whose value starts with ``urn:nbn:``
+    are persistent NBN identifiers — those resolve straight to the
+    record via the NBN resolver, bypassing the shelf-mark search UI.
     """
+    from urllib.parse import quote_plus
+
     if not value:
         return ""
+    raw = str(value).strip()
+
+    # Frankfurt records that carry a Nationalbibliographie URN are
+    # routed through the NBN resolver — it returns the actual record
+    # without going through the search UI.
+    if library == "frankfurt" and raw.lower().startswith("urn:nbn:"):
+        return f"https://nbn-resolving.org/{raw}"
+
     pattern = LIBRARY_CATALOG_URLS.get(library)
     if not pattern:
         return ""
-    return pattern.format(id=value)
+    return pattern.format(id=quote_plus(raw))


### PR DESCRIPTION
The seven `*_library_id` fields hold SHELF MARKS (e.g. `A02 MAI (MAI)`, `Ez 6310<a>`), not catalog IDs. Legacy templates queried `any,exact,{id}` on record-by-ID slots → 0 hits. Several Primo instances have also migrated to Alma-Primo VE URLs.

Updates per library:

- **Bar Ilan / British Library / HUJI / Tel Aviv** → Primo VE search URLs with `query=any,contains,{id}` + current `vid` + `search_scope`.
- **Berlin** → stabikat.de Search/Results.
- **Frankfurt** → hds.hebis.de Search/Results. Special-cased: `urn:nbn:*` values route through `https://nbn-resolving.org/<urn>` for direct record access.
- **New York (Columbia)** → unchanged structure, now URL-encoded.

`library_catalog_url()` wraps every id with `urllib.parse.quote_plus`.

Sample resolved URLs:
```
frankfurt  'urn:nbn:de:hebis:30-180012126007'  -> https://nbn-resolving.org/urn:nbn:de:hebis:30-180012126007
frankfurt  'MPQ 110, F. 8639'                  -> https://hds.hebis.de/ubffm/Search/Results?lookfor=MPQ+110%2C+F.+8639&type=AllFields
bar_ilan   'A02 MAI (MAI)'                     -> https://biu.primo.exlibrisgroup.com/discovery/search?query=any,contains,A02+MAI+%28MAI%29&tab=Everything&search_scope=MyInst_and_CI&vid=972BIU_VU1
```

42/42 tests, flake8 clean. Note: each library's Primo `vid` / `search_scope` may need fine-tuning when the user verifies in a browser — APIs are moving targets.