### PR TITLE
chore(audits): reconnect remaining content-mention orphans

### DIFF
--- a/docs/audits/orphan_place_mentions.csv
+++ b/docs/audits/orphan_place_mentions.csv
@@ -1,28 +1,5 @@
 orphan_uuid,orphan_name,model,entity_pk,entity_slug,field,snippet
 7c5c5e10-66d9-4d21-85d9-dc0003ba5e92,Kiel,Book,6d04a11f-9960-42e3-b344-c0925e754ee5,actenstucke-zur-geschichte-der-erhebung-der-juden-zu-burgern-der-republik-batavien,references_notes,"AK: UB Rostock: CIc-1160.2 Katalog Uni Kiel Kopie bereits erhalten, gescannt auf CD"
 7c5c5e10-66d9-4d21-85d9-dc0003ba5e92,Kiel,Book,1bccabf3-0c22-40aa-8b2d-eca337c0168e,apologie-der-menschenrechte-oder-philosophisch-kritische-beleuchtung-der-schrift,volumes_notes,UB Kiel: Ka 9256
-45eaaa97-a334-4546-9c2c-cd1cd232a855,Polen,Book,b01c1274-e461-406f-a279-a7985f95316e,die-juden-oder-die-nothwendige-reformation-der-juden-in-der-republik-polen,name,nothwendige Reformation der Juden in der Republik Polen
-45eaaa97-a334-4546-9c2c-cd1cd232a855,Polen,Book,b01c1274-e461-406f-a279-a7985f95316e,die-juden-oder-die-nothwendige-reformation-der-juden-in-der-republik-polen,dedications_notes,Ihrer Majestät dem Könige von Polen allerunterthänigst gewidmet vom Uebersetzer.
-45eaaa97-a334-4546-9c2c-cd1cd232a855,Polen,Book,b01c1274-e461-406f-a279-a7985f95316e,die-juden-oder-die-nothwendige-reformation-der-juden-in-der-republik-polen,full_title,nothwendige Reformation der Juden in der Republik Polen: Aus dem Polnischen eines unbenanten Verfassers ü
 7c5c5e10-66d9-4d21-85d9-dc0003ba5e92,Kiel,Book,92d52b9e-32de-4cc2-9418-2da169091ab0,rede-gehalten-in-der-versammlung-der-gesellschaft-zur-unterhaltung-einer-judischen-freyschule,copy_of_book_used,Universitätsbibliothek Kiel: 5 in Kf 3166
 55210f57-b229-47e0-8833-638a0b445e5e,Lieben,Book,c7ba821f-4e10-4cfe-85c5-94b7488ee3e8,trauerrede-uber-das-ableben-des-weisesten-monarchen-friedrich-des-zweiten,target_audience_notes,"ישנה מדי פעם פניה ל""אחי וריעי"" (ובתרגום לגרמנית: Lieben Brüder משתי הפסקאות שחותמות את הספר (הפונות ישירו"
-310df71a-b23b-416c-875a-2ede37ffeb4d,Hirschberg,Book,ff5dc661-1a95-4188-8f16-286f18bdd544,oder-das-judenthum-2,sources_references,"ehungs-Methode bey der jüdischen Jugend, Breslau, Hirschberg a. Lissa (Korn) 1800."
-9b248b36-c0d9-493e-a590-00a1cade9baa,Florenz,Book,756331fc-9f56-49f7-b539-2f776449592b,book-756331fc,full_title,"en vom Freytage den 8ten April 1797, Nr. 57, Art. Florenz den 20sten März.)"
-9b248b36-c0d9-493e-a590-00a1cade9baa,Florenz,Book,756331fc-9f56-49f7-b539-2f776449592b,book-756331fc,title_in_latin_characters,"en vom Freytage den 8ten April 1797, Nr. 57, Art. Florenz den 20sten März.)"
-d1474318-6cff-438b-99db-f1dbfb93f8e3,Hungary,Book,08bacf86-347c-46fe-baec-9a89852e23f4,book-08bacf86,secondary_sources,"an Jewry and Its Impact on Haskalah and Reform in Hungary”. In: Toward Modernity. New Brunswich, NJ: Transa"
-e8862065-19f4-47fd-8762-e1c6082e6b80,Arad,Book,010c3164-4956-48b8-96fb-a8280df1b2fc,book-010c3164,full_title,"אש אמנה ... נשמה חיה ... דירת אהרן [Synagogus in Arad R. Aaran Charin in hoc opusculo, cui titulum ex G"
-e8862065-19f4-47fd-8762-e1c6082e6b80,Arad,Book,010c3164-4956-48b8-96fb-a8280df1b2fc,book-010c3164,title_in_latin_characters,".. Neshamah ḥayah ... Dirat Aharon [Synagogus in Arad R. Aaran Charin in hoc opusculo, cui titulum ex G"
-45eaaa97-a334-4546-9c2c-cd1cd232a855,Polen,Production,fee9739e-c643-431a-b084-ce1ba11e0f28,,title,"nothwendige Reformation der Juden in der Republik Polen - Author,Translator"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,53a3db54-7cb1-46dc-9da8-9e8308ca24b5,,title,"Dubno, Salomon - דובנא, שלמה - אבל יחיד - Author"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,d373da3c-8336-460d-bef3-0e88e6168cc9,,title,"Dubno, Salomon - דובנא, שלמה - אהבת ציון - Editor"
-6b49f559-e45c-447a-b46c-872d3b76506f,Troplowitz,Production,6c06464b-73ea-48ba-8453-1a80fa1228b7,,title,"Troplowitz, Joseph Ephrati - האפרתי, יוסף מטראפלוויץ - אלון"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,4d3f03bb-6274-40c2-936a-dd33295fbf41,,title,"Dubno, Salomon - דובנא, שלמה - לישרים תהלה - Mevi La'Df"
-6b49f559-e45c-447a-b46c-872d3b76506f,Troplowitz,Production,e4f2c010-34fa-4a7d-becb-7f2ce39fa706,,title,"Troplowitz, Joseph Ephrati - האפרתי, יוסף מטראפלוויץ - מלוכת"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,d9f7d3cb-d2df-436e-b783-d1d97176f7c5,,title,"Dubno, Salomon - דובנא, שלמה - ספר ברכת יוסף - Author"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,d440fe4d-1098-49e1-9df3-a5b96ea264d9,,title,"Dubno, Salomon - דובנא, שלמה - ספר נתיבות השלום א - Com"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,a0df280b-7cf3-4962-a09f-a449346c78f3,,title,"Dubno, Salomon - דובנא, שלמה - ספר שערי נעימה - Mevi La"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,cc57ab18-347e-4440-89a5-dc220e68e5e5,,title,"Dubno, Salomon - דובנא, שלמה - עלים לתרופה - Author"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,bd727334-a1a1-4929-a581-93ce1994f127,,title,"Dubno, Salomon - דובנא, שלמה - קול שמחה - Author"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,7a7a0fdb-a106-4838-8dcd-4d4c0b3b7f25,,title,"Dubno, Salomon - דובנא, שלמה - Nachricht von der Jüdisc"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,d546b9ba-b7f2-4bca-96c2-df99ac494ff0,,title,"Dubno, Salomon - דובנא, שלמה - ספר נתיבות השלום ב - Com"
-c6519d80-770a-4ae1-b1ba-04064fe08cfb,Dubno,Production,6c21afa2-371f-4259-a26c-d175a9ac5d89,,title,"Dubno, Salomon - דובנא, שלמה - תיקון סופרים - Author"

--- a/home/migrations/0034_reconnect_content_mentions.py
+++ b/home/migrations/0034_reconnect_content_mentions.py
@@ -1,0 +1,149 @@
+"""
+Promote five remaining content-mention orphans into proper Mention
+rows and set place_of_birth for the three persons whose toponymic
+surname matches a historically-attested birthplace.
+
+This migration finalises the orphan-cities sweep tracked in
+``docs/audits/orphan_place_mentions.csv``. The Pränumeranten cohort
+was handled by the ``reconnect_orphan_place_mentions`` management
+command (PR #111). What is fixed here are the residual cases that
+fell outside that command's per-field policy:
+
+Mentions (description=NULL — no clean MentionDescription fits):
+
+- Polen      (Book b01c1274 — "Die Juden Oder Die nothwendige
+              Reformation der Juden in der Republik Polen")
+- Hungary    (Book 08bacf86 — secondary_sources cites
+              "Jewry … Hungary")
+- Hirschberg (Book ff5dc661 — sources_references cites
+              "Hirschberg a. Lissa")
+- Florenz    (Book 756331fc — full_title carries
+              "Art. Florenz den 20sten März")
+- Arad       (Book 010c3164 — full_title carries
+              "Synagogus in Arad R. Aaran Charin")
+
+place_of_birth fills (historically attested):
+
+- Salomon Dubno (1738-1813)        -> Dubno, Wolhynia
+- Joseph Ephrati                   -> Troplowitz, Silesia
+
+Skipped on purpose:
+
+- Kiel — appears only as "Universitätsbibliothek Kiel / UB Kiel"
+  library-shelfmark, not a content mention of the city.
+- Lieben — appears only as the German word "Lieben (Brüder)" in
+  target_audience_notes, not the Czech town Libeň.
+
+Idempotent: each operation checks current state before writing, so
+re-running the migration is a no-op.
+"""
+from __future__ import annotations
+
+from django.db import migrations
+
+
+MENTIONS = [
+    # (book_pk, city_pk, city_name_for_log)
+    (
+        "b01c1274-e461-406f-a279-a7985f95316e",
+        "45eaaa97-a334-4546-9c2c-cd1cd232a855",
+        "Polen",
+    ),
+    (
+        "08bacf86-347c-46fe-baec-9a89852e23f4",
+        "d1474318-6cff-438b-99db-f1dbfb93f8e3",
+        "Hungary",
+    ),
+    (
+        "ff5dc661-1a95-4188-8f16-286f18bdd544",
+        "310df71a-b23b-416c-875a-2ede37ffeb4d",
+        "Hirschberg",
+    ),
+    (
+        "756331fc-9f56-49f7-b539-2f776449592b",
+        "9b248b36-c0d9-493e-a590-00a1cade9baa",
+        "Florenz",
+    ),
+    (
+        "010c3164-4956-48b8-96fb-a8280df1b2fc",
+        "e8862065-19f4-47fd-8762-e1c6082e6b80",
+        "Arad",
+    ),
+]
+
+# Person pref_label substring -> City name (substring on City.name)
+PLACE_OF_BIRTH = [
+    ("Dubno, Salomon", "Dubno"),
+    ("Troplowitz, Joseph Ephrati", "Troplowitz"),
+]
+
+
+def apply(apps, schema_editor):
+    Book = apps.get_model("home", "Book")
+    City = apps.get_model("home", "City")
+    Mention = apps.get_model("home", "Mention")
+    Person = apps.get_model("home", "Person")
+
+    for book_pk, city_pk, _label in MENTIONS:
+        book = Book.objects.filter(pk=book_pk).first()
+        city = City.objects.filter(pk=city_pk).first()
+        if book is None or city is None:
+            continue
+        exists = Mention.objects.filter(
+            book=book,
+            mentionee_city=city,
+            mentionee_description__isnull=True,
+        ).exists()
+        if exists:
+            continue
+        Mention.objects.create(
+            book=book,
+            mentionee=None,
+            mentionee_city=city,
+            mentionee_description=None,
+        )
+
+    for surname_match, city_name in PLACE_OF_BIRTH:
+        city = City.objects.filter(name=city_name).first()
+        if city is None:
+            continue
+        qs = Person.objects.filter(
+            pref_label__startswith=surname_match,
+            place_of_birth__isnull=True,
+        )
+        for person in qs:
+            person.place_of_birth = city
+            person.save(update_fields=["place_of_birth"])
+
+
+def revert(apps, schema_editor):
+    City = apps.get_model("home", "City")
+    Mention = apps.get_model("home", "Mention")
+    Person = apps.get_model("home", "Person")
+
+    for book_pk, city_pk, _label in MENTIONS:
+        Mention.objects.filter(
+            book_id=book_pk,
+            mentionee_city_id=city_pk,
+            mentionee_description__isnull=True,
+        ).delete()
+
+    for surname_match, city_name in PLACE_OF_BIRTH:
+        city = City.objects.filter(name=city_name).first()
+        if city is None:
+            continue
+        Person.objects.filter(
+            pref_label__startswith=surname_match,
+            place_of_birth=city,
+        ).update(place_of_birth=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("home", "0033_populate_topic_occupation_slugs"),
+    ]
+
+    operations = [
+        migrations.RunPython(apply, revert),
+    ]


### PR DESCRIPTION
## Summary
Migration 0034 promotes the residual content-mention orphans into proper \`Mention\` rows and fills \`place_of_birth\` for two persons whose toponymic surname matches a historically-attested birthplace.

### Mentions added (description=NULL)
| City | Book | Why it qualifies |
|---|---|---|
| Polen | "Reformation der Juden in der Republik Polen" | Book is *about* Polen |
| Hungary | secondary_sources cites "Jewry … Hungary" | Source mentions Hungary |
| Hirschberg | "Hirschberg a. Lissa (Korn) 1800" | Source publication place |
| Florenz | "Art. Florenz den 20sten März" | Content of the title |
| Arad | "Synagogus in Arad R. Aaran Charin" | Content of the title |

### place_of_birth filled
| Person | Place |
|---|---|
| Salomon Dubno (1738–1813) | Dubno, Wolhynia |
| Joseph Ephrati | Troplowitz, Silesia |

### Deliberately skipped
- **Kiel** — appears only as "Universitätsbibliothek Kiel" library shelfmarks, not city content.
- **Lieben** — "Lieben Brüder" is the German word "lieben", not Libeň/Prag.

Both stay orphan and will be archived in the next \`mark_orphan_places_draft --apply\` pass.

## Run today
- Orphan-city count: 95 → 88 (7 reconnected)
- Cumulative since start of sweep: 112 → 88 (24 cities reconnected via PRs #110/#111/this)
- Worklist CSV shrinks from 27 → 4 rows (the 4 Kiel/Lieben false positives kept on record)

## Test plan
- [ ] CI green
- [ ] Migration is idempotent (re-applying is a no-op)
- [ ] Salomon Dubno detail page now shows place_of_birth=Dubno
- [ ] Joseph Ephrati detail page now shows place_of_birth=Troplowitz