### PR TITLE
feature(places): multi-language Wikidata search in city matcher

### DIFF
--- a/home/management/commands/enrich_cities_from_wikidata.py
+++ b/home/management/commands/enrich_cities_from_wikidata.py
@@ -194,12 +194,28 @@ class Command(BaseCommand):
             if not name:
                 continue
 
-            candidates = self._search_wikidata(
-                session, name,
-                limit=options["limit_candidates"],
-                language=options["language"],
-            )
-            time.sleep(options["delay"])
+            # Multi-language search: a single language=en pass misses
+            # Hebrew-script names entirely and a few quirks like
+            # "Vienna" where wbsearch ranks US homonyms before Wien
+            # (Q1741). Pull candidates in en + de + he, merge by QID
+            # while preserving each candidate's BEST search position
+            # across all passes.
+            languages = ("en", "de", "he")
+            seen = {}
+            for lang in languages:
+                hits = self._search_wikidata(
+                    session, name,
+                    limit=options["limit_candidates"],
+                    language=lang,
+                )
+                time.sleep(options["delay"])
+                for pos, h in enumerate(hits):
+                    qid = h["id"]
+                    if qid not in seen or pos < seen[qid][0]:
+                        seen[qid] = (pos, h)
+            candidates = [
+                h for _, h in sorted(seen.values(), key=lambda t: t[0])
+            ]
 
             scored = []
             for pos, cand in enumerate(candidates):


### PR DESCRIPTION
## Summary
The first full sweep run revealed two systematic gaps in the single-\`language=en\` wbsearchentities query:

1. **Vienna** — Wikidata's English search returned only US homonyms + Windows 7 in the top 5. The real Wien (Q1741) was nowhere to be seen, so even with the rank bonus the matcher dropped it to "manual" and the score didn't beat Q1002926 (Virginia town) by the confidence margin.
2. **All 20 Hebrew-script city rows** ("ולאטאווי", "ווערדין", …) scored 0 because Hebrew labels weren't being searched at all.

## Change
Run wbsearchentities in **en + de + he** per city. Merge the hit lists by QID, preserving each candidate's BEST search position across the three passes. The downstream scoring (rank bonus, P31, P17, P625, sitelinks) is unchanged.

## Verified
- **Vienna**: Q1741 (Wien, AT) now arrives at position 0 with full sitelink + coords + country signal — moves to "auto".
- **Hebrew rows that exist on Wikidata** surface them; rows whose Yiddish spelling has no Wikidata entry cleanly fall through to "manual" (correct behavior).

## Cost
~3× search-request volume per city (3 searches + N entity fetches instead of 1 search + N fetches). At the default 1.0s politeness delay a 225-row sweep grows from ~20 min to ~25 min.

## Test plan
- [ ] CI green (42 tests still pass)
- [ ] Smoke against \`Vienna\` returns Q1741 at position 0
- [ ] Re-run full sweep — Vienna moves to auto, Hebrew rows with real Wikidata equivalents pick up candidates