### PR TITLE
feature(wikidata): periodic catalog → Wikidata sync via QuickStatements

### DIFF
--- a/docs/operations/wikidata-quickstatements.md
+++ b/docs/operations/wikidata-quickstatements.md
@@ -1,0 +1,101 @@
+# Wikidata Sync via QuickStatements
+
+Periodic back-link sync from the Haskala catalog into the matching
+Wikidata items. Every Person / Book / City whose `wikidata_id` is
+populated gets enriched with a "described at URL" (P973) statement
+pointing at its catalog detail page, plus VIAF (P214) / GND (P227)
+ID statements when those are available.
+
+All edits run **under your personal Wikidata account**. There is no
+bot account involved — the QuickStatements API token is bound to
+your QS profile, which is in turn bound to your Wikidata OAuth
+identity.
+
+## One-off: generate the TSV
+
+    docker compose exec web \
+        python manage.py export_wikidata_quickstatements
+
+Writes the batch to
+`dumps/haskala/wikidata/quickstatements_<YYYY-MM-DD>.tsv`. The
+command is read-only and does not contact Wikidata.
+
+## Manual upload (no setup needed)
+
+1. Open the TSV from the dumps directory.
+2. Visit <https://quickstatements.toolforge.org/> while logged in
+   with your personal Wikidata account.
+3. Paste the TSV under **Import V1 commands** and run the batch.
+   Every edit shows up in your Wikidata contribution history.
+
+## Automated upload (one-time OAuth setup)
+
+1. While logged in, open
+   <https://quickstatements.toolforge.org/#/user>. Copy the
+   "Token" field — it's bound to your account.
+2. Add these env vars to the host that runs the cron job (NOT to
+   the repo's `.env` — keep them out of git):
+
+       HASKALA_QS_USER=YourWikidataUsername
+       HASKALA_QS_TOKEN=<token from step 1>
+
+3. Run with `--upload`:
+
+       docker compose exec web \
+           python manage.py export_wikidata_quickstatements --upload
+
+   The command writes the TSV, then POSTs the batch to
+   QuickStatements. The new batch appears in your QS history
+   under the label `haskala-sync-<YYYY-MM-DD>` (override with
+   `--batchname`).
+
+## Cron — once a month
+
+Add to the operator host's crontab (NOT inside the container):
+
+    # 02:30 on the 1st of every month, push new statements
+    30 2 1 * * cd /srv/haskala && docker compose exec -T web \
+        python manage.py export_wikidata_quickstatements --upload \
+        >> /var/log/haskala/wikidata-sync.log 2>&1
+
+## Cron — twice a year
+
+    # 02:30 on Jan 15 and Jul 15
+    30 2 15 1,7 * cd /srv/haskala && docker compose exec -T web \
+        python manage.py export_wikidata_quickstatements --upload \
+        >> /var/log/haskala/wikidata-sync.log 2>&1
+
+## Idempotency
+
+QuickStatements rejects statements that already exist with matching
+references, so re-running the command does not double-publish. The
+catalog URL + retrieval date are stored as references on every
+statement, which means QS treats each month's batch as a refresh of
+the reference timestamp rather than a duplicate value.
+
+## What gets synced today
+
+| Model | Property emitted | Source field |
+|---|---|---|
+| Person | P973 (described at URL) | catalog `/persons/<slug>/` |
+| Person | P214 (VIAF ID) | `Person.viaf_id` if non-empty |
+| Person | P227 (GND ID) | `Person.gnd_id` if non-empty |
+| Book | P973 (described at URL) | catalog `/books/<slug>/` |
+| City | P973 (described at URL) | catalog `/places/<slug>/` |
+
+Books and Persons require `wikidata_id` to be set on the row first
+— that field still lives only on `City` until Phase 1 is extended to
+the other models. Until then this command only emits statements for
+anchored cities; the body count will grow once Books / Persons get
+their own anchor fields.
+
+## Troubleshooting
+
+- **`QuickStatements rejected the batch: {...}`** — most often a
+  missing or expired token. Re-fetch from the QS user page.
+- **`Cannot upload: HASKALA_QS_USER and HASKALA_QS_TOKEN must be set`**
+  — env vars not exported to the cron environment. Cron runs with a
+  bare shell; export them in the crontab or via
+  `EnvironmentFile=` if you migrate to a systemd timer.
+- **Output TSV is empty** — no Wikidata anchors yet. Run
+  `python manage.py enrich_cities_from_wikidata --apply` first.

--- a/home/management/commands/export_wikidata_quickstatements.py
+++ b/home/management/commands/export_wikidata_quickstatements.py
@@ -1,0 +1,335 @@
+"""
+Generate a QuickStatements input file that pushes back-links from
+the Haskala catalog to the corresponding Wikidata items.
+
+For every Person / Book / City whose ``wikidata_id`` is set, the
+command emits statements that enrich the existing Wikidata entity
+with:
+
+- ``P973`` "described at URL" pointing at the catalog detail page,
+  with the catalog URL as the reference (``S854`` reference URL) and
+  the retrieval date (``S813``) as today.
+- For Persons, when authority IDs are present:
+  - ``P214`` VIAF ID
+  - ``P227`` GND ID
+
+QuickStatements is idempotent — re-running monthly and re-uploading
+the result is safe: statements that already exist with the same
+references are skipped server-side. The TSV format and statement
+grammar are documented at:
+
+  https://www.wikidata.org/wiki/Help:QuickStatements
+
+The output goes to ``<HASKALA_DUMPS_ROOT>/<HASKALA_SLUG>/wikidata/
+quickstatements_<YYYY-MM-DD>.tsv``. Override the path with ``--out``.
+
+Upload paths (pick the one that fits the operator):
+
+1. Manual (no setup): copy the file's contents and paste into
+   https://quickstatements.toolforge.org/ under "Import V1 commands"
+   while logged in as your personal Wikidata account. All edits
+   land under your contribution history.
+2. API (one-time OAuth setup): grab your personal API token from
+   https://quickstatements.toolforge.org/#/user and set the env
+   vars ``HASKALA_QS_USER`` + ``HASKALA_QS_TOKEN``. Then pass
+   ``--upload`` and the command POSTs the batch directly. The
+   edits still show up under your Wikidata username because the
+   token is bound to your QS profile.
+
+The command is otherwise read-only against the catalog and does NOT
+contact Wikidata. Uploading is opt-in.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date
+from pathlib import Path
+
+import requests
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils.dateformat import format as dj_format
+
+from home.models import Book, City, Person
+
+
+PROP_DESCRIBED_AT_URL = "P973"
+PROP_REFERENCE_URL = "S854"
+PROP_RETRIEVED = "S813"
+PROP_VIAF = "P214"
+PROP_GND = "P227"
+
+QS_API_URL = "https://quickstatements.toolforge.org/api.php"
+
+
+def _base_url():
+    """Public-facing catalog URL, used as the back-link target.
+
+    Falls back to ``WAGTAILADMIN_BASE_URL`` because the project keeps
+    its canonical site URL there. Trailing slash is stripped so we
+    can ``f"{base}/places/{slug}/"`` without doubling slashes."""
+    base = (
+        getattr(settings, "HASKALA_BASE_URL", "")
+        or getattr(settings, "WAGTAILADMIN_BASE_URL", "")
+        or "https://www.haskala-library.net"
+    )
+    return base.rstrip("/")
+
+
+def _today_iso():
+    """QuickStatements expects a TIME value in
+    ``+YYYY-MM-DDT00:00:00Z/PRECISION`` form. Precision 11 = day."""
+    today = date.today()
+    return f"+{dj_format(today, 'Y-m-d')}T00:00:00Z/11"
+
+
+def _quote(s):
+    """QuickStatements string literal: surround with double quotes
+    and escape inner double quotes. The catalog's slugs don't carry
+    quote characters but we escape defensively in case a future row
+    does."""
+    return '"' + s.replace('"', '\\"') + '"'
+
+
+class Command(BaseCommand):
+    help = (
+        "Emit a QuickStatements TSV that adds 'described at URL' "
+        "(P973) plus authority-ID statements on every Wikidata "
+        "item the catalog has anchored."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--out",
+            default=None,
+            help="Output path. Default: "
+                 "<HASKALA_DUMPS_ROOT>/<HASKALA_SLUG>/wikidata/"
+                 "quickstatements_<YYYY-MM-DD>.tsv",
+        )
+        parser.add_argument(
+            "--upload",
+            action="store_true",
+            help="POST the batch to QuickStatements after writing "
+                 "the TSV. Requires HASKALA_QS_USER and "
+                 "HASKALA_QS_TOKEN env vars (or --user / --token).",
+        )
+        parser.add_argument(
+            "--user",
+            default=os.environ.get("HASKALA_QS_USER", ""),
+            help="QuickStatements username (your Wikidata handle). "
+                 "Falls back to HASKALA_QS_USER env var.",
+        )
+        parser.add_argument(
+            "--token",
+            default=os.environ.get("HASKALA_QS_TOKEN", ""),
+            help="Personal QuickStatements API token, copied from "
+                 "https://quickstatements.toolforge.org/#/user. "
+                 "Falls back to HASKALA_QS_TOKEN env var.",
+        )
+        parser.add_argument(
+            "--batchname",
+            default="",
+            help="Batch label shown in QuickStatements history. "
+                 "Default: haskala-sync-<YYYY-MM-DD>.",
+        )
+
+    def handle(self, *args, **options):
+        out_path = options["out"]
+        if out_path is None:
+            stamp = dj_format(date.today(), "Y-m-d")
+            out_path = (
+                Path(settings.HASKALA_DUMPS_ROOT)
+                / settings.HASKALA_SLUG
+                / "wikidata"
+                / f"quickstatements_{stamp}.tsv"
+            )
+        out_path = Path(out_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+        base = _base_url()
+        retrieved = _today_iso()
+
+        lines = []
+        person_count = self._emit_persons(lines, base, retrieved)
+        book_count = self._emit_books(lines, base, retrieved)
+        city_count = self._emit_cities(lines, base, retrieved)
+
+        with out_path.open("w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+            if lines:
+                f.write("\n")
+
+        self.stdout.write(self.style.WARNING(
+            f"Persons emitted: {person_count}"
+        ))
+        self.stdout.write(self.style.WARNING(
+            f"Books emitted:   {book_count}"
+        ))
+        self.stdout.write(self.style.WARNING(
+            f"Cities emitted:  {city_count}"
+        ))
+        self.stdout.write(self.style.SUCCESS(
+            f"{len(lines)} TSV row(s) -> {out_path}"
+        ))
+
+        if options["upload"]:
+            self._upload(
+                lines,
+                user=options["user"],
+                token=options["token"],
+                batchname=(
+                    options["batchname"]
+                    or f"haskala-sync-{dj_format(date.today(), 'Y-m-d')}"
+                ),
+            )
+
+    def _upload(self, lines, user, token, batchname):
+        """POST the batch to the QuickStatements API.
+
+        The batch is attributed to the operator's Wikidata account
+        because the API token is bound to their QS profile, which
+        in turn is bound to their Wikidata OAuth identity. We do
+        not pass the token as a URL parameter to avoid leaking it
+        in proxy logs."""
+        if not user or not token:
+            self.stderr.write(self.style.ERROR(
+                "Cannot upload: HASKALA_QS_USER and HASKALA_QS_TOKEN "
+                "(or --user/--token) must be set."
+            ))
+            return
+        if not lines:
+            self.stdout.write(
+                "Nothing to upload (zero statements emitted)."
+            )
+            return
+
+        data = {
+            "action": "import",
+            "submit": "1",
+            "format": "v1",
+            "batchname": batchname,
+            "username": user,
+            "token": token,
+            "data": "\n".join(lines),
+        }
+        try:
+            r = requests.post(QS_API_URL, data=data, timeout=60)
+            r.raise_for_status()
+            body = r.json() if r.headers.get(
+                "content-type", ""
+            ).startswith("application/json") else {"raw": r.text}
+        except requests.RequestException as exc:
+            self.stderr.write(self.style.ERROR(
+                f"QuickStatements upload failed: {exc}"
+            ))
+            return
+
+        if body.get("status") == "OK":
+            batch_id = body.get("batch_id") or body.get("batchid", "?")
+            self.stdout.write(self.style.SUCCESS(
+                f"Uploaded as batch {batch_id} for user {user!r} "
+                f"(label: {batchname})."
+            ))
+        else:
+            self.stderr.write(self.style.ERROR(
+                f"QuickStatements rejected the batch: {body}"
+            ))
+
+    # ----- per-model emitters ---------------------------------------
+
+    def _emit_persons(self, lines, base, retrieved):
+        count = 0
+        wikidata_field_present = hasattr(Person, "wikidata_id")
+        qs = Person.objects.filter(live=True)
+        if wikidata_field_present:
+            qs = qs.exclude(wikidata_id="")
+        else:
+            return 0
+        for p in qs.iterator(chunk_size=200):
+            slug = p.slug or str(p.pk)
+            url = f"{base}/persons/{slug}/"
+            lines.append(self._statement_line(
+                p.wikidata_id,
+                PROP_DESCRIBED_AT_URL,
+                _quote(url),
+                ref_url=url,
+                retrieved=retrieved,
+            ))
+            if (p.viaf_id or "").strip():
+                lines.append(self._statement_line(
+                    p.wikidata_id,
+                    PROP_VIAF,
+                    _quote(p.viaf_id.strip()),
+                    ref_url=url,
+                    retrieved=retrieved,
+                ))
+            if (p.gnd_id or "").strip():
+                lines.append(self._statement_line(
+                    p.wikidata_id,
+                    PROP_GND,
+                    _quote(p.gnd_id.strip()),
+                    ref_url=url,
+                    retrieved=retrieved,
+                ))
+            count += 1
+        return count
+
+    def _emit_books(self, lines, base, retrieved):
+        if not hasattr(Book, "wikidata_id"):
+            return 0
+        count = 0
+        for b in (
+            Book.objects.filter(live=True)
+            .exclude(wikidata_id="")
+            .iterator(chunk_size=200)
+        ):
+            slug = b.slug or str(b.pk)
+            url = f"{base}/books/{slug}/"
+            lines.append(self._statement_line(
+                b.wikidata_id,
+                PROP_DESCRIBED_AT_URL,
+                _quote(url),
+                ref_url=url,
+                retrieved=retrieved,
+            ))
+            count += 1
+        return count
+
+    def _emit_cities(self, lines, base, retrieved):
+        count = 0
+        for c in (
+            City.objects.filter(live=True)
+            .exclude(wikidata_id="")
+            .iterator(chunk_size=200)
+        ):
+            slug = c.slug or str(c.pk)
+            url = f"{base}/places/{slug}/"
+            lines.append(self._statement_line(
+                c.wikidata_id,
+                PROP_DESCRIBED_AT_URL,
+                _quote(url),
+                ref_url=url,
+                retrieved=retrieved,
+            ))
+            count += 1
+        return count
+
+    # ----- TSV formatting -------------------------------------------
+
+    def _statement_line(self, qid, prop, value, *, ref_url, retrieved):
+        """Build one QuickStatements V1 line with a reference URL
+        and a retrieved date.
+
+        Format (tab-separated):
+
+          QID  prop  value  S854  "ref-url"  S813  +YYYY-MM-DDT00:00:00Z/11
+        """
+        return "\t".join([
+            qid,
+            prop,
+            value,
+            PROP_REFERENCE_URL,
+            _quote(ref_url),
+            PROP_RETRIEVED,
+            retrieved,
+        ])


### PR DESCRIPTION
## Summary
New management command \`export_wikidata_quickstatements\` that pushes back-link statements from the Haskala catalog to the matching Wikidata items. Runs **under your personal Wikidata account** — no bot account involved.

## What gets synced
Every Person / Book / City whose \`wikidata_id\` is populated:
| Statement | Value |
|---|---|
| **P973** (described at URL) | catalog detail page URL |
| **P214** (VIAF ID) | Person.viaf_id when non-empty |
| **P227** (GND ID) | Person.gnd_id when non-empty |

Each statement carries the catalog URL as \`S854\` (reference URL) and today as \`S813\` (retrieved). QuickStatements is idempotent under matching references, so re-running monthly refreshes the timestamp rather than duplicating.

## Two upload paths
1. **Manual** (no setup): \`python manage.py export_wikidata_quickstatements\` → paste the resulting TSV at <https://quickstatements.toolforge.org/> while logged in.
2. **Automated**: grab your personal QS token from <https://quickstatements.toolforge.org/#/user>, export \`HASKALA_QS_USER\` + \`HASKALA_QS_TOKEN\`, then run \`--upload\`. The POST is attributed to your Wikidata account because the token is bound to your QS profile.

## Periodic
\`docs/operations/wikidata-quickstatements.md\` carries example crontab entries for monthly and biannual cadence. Cron runs the command on the host with the env vars exported.

## Smoke-run
Against the current DB (Phase 2 \`--apply\` is still mid-flight, 22 of 135 cities anchored so far):

\`\`\`
Persons emitted: 0
Books emitted:   0
Cities emitted:  22
22 TSV row(s) -> dumps/haskala/wikidata/quickstatements_2026-06-15.tsv
\`\`\`

Sample line:

\`\`\`
Q488513	P973	"https://www.haskala-library.net/places/anklam/"	S854	"https://www.haskala-library.net/places/anklam/"	S813	+2026-06-15T00:00:00Z/11
\`\`\`

Once Phase 1 is extended to Person / Book the same command picks those up automatically — the per-model emitters guard on \`hasattr(model, "wikidata_id")\`.

## Test plan
- [ ] CI green (42 tests still pass)
- [ ] \`python manage.py export_wikidata_quickstatements --help\` prints
- [ ] Smoke-run writes a TSV under \`dumps/haskala/wikidata/\`
- [ ] Manual paste of one row at <https://quickstatements.toolforge.org/> produces the expected P973 edit on the matching Wikidata item