### PR TITLE
chore(audits): manual review list for the 89 unanchored cities

### DIFF
--- a/docs/audits/manual_review_list.md
+++ b/docs/audits/manual_review_list.md
@@ -1,0 +1,95 @@
+# Manual review list — 89 unanchored cities
+
+Generated after the Phase 2 --apply run. Sorted by best-candidate score (high to low) so close-call confirmations come first; the tail (score 0) is the cohort whose Yiddish/Hebrew spellings have no Wikidata equivalent and need a manual decision.
+
+| # | City | Best candidate | Score | Runner-up | Edit |
+|---:|---|---|---:|---|---|
+| 1 | Seesen | [Q540934](https://www.wikidata.org/wiki/Q540934) Seesen | 26 | Q32297790 (24) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/426d0c2e-20cd-42bc-92a5-df10d5251dcf/) |
+| 2 | Weikersheim | [Q61835](https://www.wikidata.org/wiki/Q61835) Weikersheim | 26 | Q32753275 (24) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/649fa979-76cf-4a9d-a145-84a7b02a35b7/) |
+| 3 | Prag | [Q1085](https://www.wikidata.org/wiki/Q1085) Prague | 25 | Q992285 (22) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/6d8abc02-c423-4972-8802-f9a4af90d733/) |
+| 4 | Altona | [Q1630](https://www.wikidata.org/wiki/Q1630) Altona | 24 | Q443946 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/c8055655-82be-47d9-bf16-340ffcd4a994/) |
+| 5 | Bruchsal | [Q7059](https://www.wikidata.org/wiki/Q7059) Bruchsal | 24 | Q318279 (22) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/2e3d1b6a-8421-4ea7-8a4f-3f0e29277ec4/) |
+| 6 | Hechingen | [Q494529](https://www.wikidata.org/wiki/Q494529) Hechingen | 24 | Q32054927 (22) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/1b05a403-73ec-4eff-8d12-56cb306a1064/) |
+| 7 | Kempen | [Q14929](https://www.wikidata.org/wiki/Q14929) Kempen | 24 | Q640493 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/b72c7ab3-3973-4203-aee8-baaf506010b3/) |
+| 8 | Cambridge | [Q350](https://www.wikidata.org/wiki/Q350) קיימברידג' | 23 | Q49111 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/ec83fd01-b178-4f04-be3a-ef0b650d8f72/) |
+| 9 | Halle | [Q2814](https://www.wikidata.org/wiki/Q2814) Halle (Saale) | 23 | Q210003 (22) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/09a762f9-cccc-4679-8b31-b9363963508f/) |
+| 10 | Königsberg | [Q1829](https://www.wikidata.org/wiki/Q1829) Kaliningrad | 23 | Q4120832 (22) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/4904192d-1d51-44d8-9c4c-7d6e0003fa60/) |
+| 11 | Landau | [Q7052](https://www.wikidata.org/wiki/Q7052) לנדאו | 23 | Q509536 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/e018e49c-7e20-4df5-882f-a5e909481802/) |
+| 12 | Lissa | [Q52892](https://www.wikidata.org/wiki/Q52892) Leszno | 23 | Q203767 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/c1e84b20-a603-411a-bfcd-ef1b82ea250d/) |
+| 13 | Ofen | [Q193478](https://www.wikidata.org/wiki/Q193478) Buda | 23 | Q1781 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/9329af8c-6d1d-4937-aeec-0edfaff03f93/) |
+| 14 | Reichenberg | [Q146351](https://www.wikidata.org/wiki/Q146351) Liberec | 23 | Q818905 (20) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/6aa2af49-ac7e-4771-a424-aefb6d607642/) |
+| 15 | Sulzbach | [Q616258](https://www.wikidata.org/wiki/Q616258) Sulzbach/Saar | 23 | Q33499358 (22) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/f4248f32-f421-458e-8324-8f933fdc04dd/) |
+| 16 | Brody | [Q465104](https://www.wikidata.org/wiki/Q465104) Brody | 22 | Q149790 (20) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/9c2132c0-2c5c-4e6c-8f30-174262db6444/) |
+| 17 | Buda | [Q193478](https://www.wikidata.org/wiki/Q193478) Buda | 22 | Q1781 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/0d9f371b-ce09-46da-9a05-224f36f522bf/) |
+| 18 | Dessau | [Q487070](https://www.wikidata.org/wiki/Q487070) Dessau | 22 | Q3828 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/15a45558-10ca-4412-bb5c-b85fcff05819/) |
+| 19 | Dubno | [Q932184](https://www.wikidata.org/wiki/Q932184) Dubno | 22 | Q2482767 (20) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/c6519d80-770a-4ae1-b1ba-04064fe08cfb/) |
+| 20 | Gorizia | [Q6596](https://www.wikidata.org/wiki/Q6596) Gorizia | 22 | Q16184 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/13a06659-2c4c-498a-b544-fb3a7fddd370/) |
+| 21 | Hagenau | [Q82501154](https://www.wikidata.org/wiki/Q82501154) Hagenau | 22 | Q22730 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/2033b5dd-acd3-4359-b193-5697915008a6/) |
+| 22 | Jeßnitz | [Q18021174](https://www.wikidata.org/wiki/Q18021174) Jessnitz | 22 | Q160977 (22) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/cf73d482-6c90-4060-9d88-24f51d675eee/) |
+| 23 | Kolin | [Q470369](https://www.wikidata.org/wiki/Q470369) Kolín | 22 | Q847318 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/adefc308-f9ea-4306-af0b-f3517e196c99/) |
+| 24 | Luneville | [Q208794](https://www.wikidata.org/wiki/Q208794) Lunéville | 22 | Q701572 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/1a8c891a-f318-4aa6-8481-683d2a3c3703/) |
+| 25 | Lviv | [Q36036](https://www.wikidata.org/wiki/Q36036) Lviv | 22 | Q164193 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/4cfd2409-0321-4ce1-bde5-0eb8ca48e9fd/) |
+| 26 | Minkowce | [Q5288827](https://www.wikidata.org/wiki/Q5288827) Minkowce | 22 | Q2089710 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/0d019cc7-72fa-4e77-b9d9-9e401780db3b/) |
+| 27 | Nimwegen | [Q13188714](https://www.wikidata.org/wiki/Q13188714) Nimwegen | 22 | Q47887 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/a3332362-420c-46fd-8bf2-cfbff57fb5e5/) |
+| 28 | Nowy Dwor Mazowiecki | [Q690039](https://www.wikidata.org/wiki/Q690039) Nowy Dwór Mazowiecki | 22 | Q587229 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/3d2309e7-1c5e-4715-8b7c-c6abb4a6880d/) |
+| 29 | Stampfen | [Q133446568](https://www.wikidata.org/wiki/Q133446568) Stampfen | 22 | Q782928 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/ff014364-187a-4b28-938f-5aa8a2cf56ee/) |
+| 30 | Zhovkva | [Q864836](https://www.wikidata.org/wiki/Q864836) Zhovkva | 22 | Q955630 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/48ca0895-a552-4770-a811-8e55a0d09fc8/) |
+| 31 | Zolochiv | [Q623594](https://www.wikidata.org/wiki/Q623594) Zolochiv | 22 | Q2608054 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/7bc04dfd-2013-4ff6-a37d-bcd8e7eee0e7/) |
+| 32 | Brieg | [Q214640](https://www.wikidata.org/wiki/Q214640) Brzeg | 21 | Q245267 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/437e4336-b851-4580-ab08-bfd8fb114f09/) |
+| 33 | Friedland | [Q183193](https://www.wikidata.org/wiki/Q183193) Pravdinsk | 21 | Q46009 (20) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/3392b057-fd36-441b-adb0-8829f4e5bc6f/) |
+| 34 | Görz | [Q6596](https://www.wikidata.org/wiki/Q6596) Gorizia | 21 | Q104731 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/48356dd2-7874-4ea1-9ebf-822ead8082b1/) |
+| 35 | Kanischa | [Q14424](https://www.wikidata.org/wiki/Q14424) Nagykanizsa | 21 | Q578327 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/723cc713-cc18-4355-80a5-7e0120d31d18/) |
+| 36 | Kreisch | [Q6787](https://www.wikidata.org/wiki/Q6787) Kreischa | 21 | Q830587 (18) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/fe870ffa-4548-43dc-a37c-ab7531e89c99/) |
+| 37 | Lemberg | [Q36036](https://www.wikidata.org/wiki/Q36036) Lviv | 21 | Q22394 (20) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/155b0b5a-6a8b-424b-885a-ac2245ef21cb/) |
+| 38 | Marienwerder | [Q326582](https://www.wikidata.org/wiki/Q326582) Kwidzyn | 21 | Q543918 (20) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/373fb090-322d-44fe-8fac-54ffc09c4d3f/) |
+| 39 | Ratibor | [Q25302](https://www.wikidata.org/wiki/Q25302) Racibórz | 21 | Q1021411 (18) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/1fe8d7d7-ac09-440c-b368-178d0c1fba73/) |
+| 40 | Sandersleben | [Q37692153](https://www.wikidata.org/wiki/Q37692153) Sandersleben (Anh) railway station | 21 | Q696853 (20) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/a9544bb3-d0c1-44c5-b6f4-8bd9fd9ae72c/) |
+| 41 | Worms | [Q604063](https://www.wikidata.org/wiki/Q604063) World Register of Marine Species | 21 | Q3852 (21) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/012e7e36-1d60-4983-a65b-917e95bba27f/) |
+| 42 | Kurland | [Q3470137](https://www.wikidata.org/wiki/Q3470137) Kurland | 20 | Q185072 (18) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/2efd21f7-a055-4632-93c5-9cb2a0722367/) |
+| 43 | Mattersdorf | [Q133447645](https://www.wikidata.org/wiki/Q133447645) Mattersdorf | 20 | Q250832 (17) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/903b4c99-8ce4-49c7-b6f3-58a8db94729c/) |
+| 44 | Schottland | [Q22](https://www.wikidata.org/wiki/Q22) Schottland | 20 | Q2809446 (18) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/8b726297-9cb5-40ec-9341-dab3d264e1c3/) |
+| 45 | Turnau | [Q691305](https://www.wikidata.org/wiki/Q691305) Turnau | 20 | Q86531133 (17) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/bcdb0699-07fd-4eae-a6ef-a2af1175a487/) |
+| 46 | Eger | [Q193719](https://www.wikidata.org/wiki/Q193719) Cheb | 19 | Q167109 (18) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/cfa58b84-f6dc-4af2-a77d-7f5e9222d035/) |
+| 47 | Friedrichsfeld | [Q563588](https://www.wikidata.org/wiki/Q563588) Friedrichsfelde | 19 | Q813975 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/d642624e-1d15-48a9-aa45-49dfd0b4d929/) |
+| 48 | Neuhaus | [Q368929](https://www.wikidata.org/wiki/Q368929) Jindřichův Hradec | 19 | Q1427820 (18) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/b22f4cad-b3ae-4913-a6b2-b1eba9340dd6/) |
+| 49 | Pfalz | [Q22880](https://www.wikidata.org/wiki/Q22880) Electoral Palatinate | 19 | Q326359 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/c751a6bb-4809-47d3-b0a5-271d8acf597e/) |
+| 50 | Trebitsch | [Q270704](https://www.wikidata.org/wiki/Q270704) Třebíč | 19 | Q1677609 (17) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/632a5430-a70c-4620-b9a1-f29e66d4f612/) |
+| 51 | Wasiliszki | [Q2632629](https://www.wikidata.org/wiki/Q2632629) Wassilischki | 19 | Q12678189 (19) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/ddd328e2-9060-4831-bde3-7e774da2b0c9/) |
+| 52 | New York | [Q60](https://www.wikidata.org/wiki/Q60) ניו יורק | 18 | Q1384 (17) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/afa590a4-f85c-4979-b90c-15e7d407be53/) |
+| 53 | Polen | [Q36](https://www.wikidata.org/wiki/Q36) Polen | 18 | Q12505991 (17) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/45eaaa97-a334-4546-9c2c-cd1cd232a855/) |
+| 54 | Brooklyn | [Q18419](https://www.wikidata.org/wiki/Q18419) Brooklyn | 17 | Q16275093 (15) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/4cc93f23-7ad1-43e6-849f-909c95b160b2/) |
+| 55 | Dobromil | [Q16275545](https://www.wikidata.org/wiki/Q16275545) Dobromil | 17 | Q268656 (17) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/abcf1501-f095-48de-a78c-0a16e082ebf1/) |
+| 56 | Jaroslaw | [Q16257268](https://www.wikidata.org/wiki/Q16257268) Jarosław | 17 | Q721928 (17) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/4c9ece89-e1fa-4732-97e8-9c8083e08285/) |
+| 57 | Rawa | [Q10952602](https://www.wikidata.org/wiki/Q10952602) Rawa | 17 | Q2133817 (16) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/fd8688b4-7114-4763-8a68-20a3b44a50d0/) |
+| 58 | Strelitz | [Q37444310](https://www.wikidata.org/wiki/Q37444310) Strelitz | 17 | Q2305455 (17) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/86ce0679-c4d0-4335-9cd0-a6b4432c7ab5/) |
+| 59 | Triesch | [Q37035043](https://www.wikidata.org/wiki/Q37035043) Triesch | 17 | Q999899 (15) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/c22f4bec-f116-40a4-a1bc-acc8f33008d8/) |
+| 60 | Troplowitz | [Q382020](https://www.wikidata.org/wiki/Q382020) Opawica | 17 | Q106070110 (15) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/6b49f559-e45c-447a-b46c-872d3b76506f/) |
+| 61 | Commentator | [Q1642960](https://www.wikidata.org/wiki/Q1642960) pundit | 16 | Q106313281 (15) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/4b87e66d-6354-4d84-bdc3-fd4fe9514a78/) |
+| 62 | מיץ | [Q8492](https://www.wikidata.org/wiki/Q8492) juice | 16 | Q11550473 (14) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/70c1a26a-af53-444b-92fa-d1c9a7408ea6/) |
+| 63 | Porizk | [Q56561880](https://www.wikidata.org/wiki/Q56561880) Pořízka | 14 | Q236154 (12) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/a3f7b989-5965-4d52-8498-29632061b3e9/) |
+| 64 | Samocz | [Q1753784](https://www.wikidata.org/wiki/Q1753784) Samoczynne hamowanie pociągu | 14 | Q1779202 (14) | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/04e7fced-4751-436c-b2f2-52a3353af7a1/) |
+| 65 | Krossen an der Oder | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/823c994c-b2b7-4c8a-8d1e-5e0d7965743b/) |
+| 66 | Landsberg/Warthe | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/21ddd11e-c63c-4249-85ae-b426efa41459/) |
+| 67 | Mesritsch | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/fea8b84c-cad6-4041-b93e-89c054a58826/) |
+| 68 | Neuzedlisch | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/0280fe90-45af-4247-a0a8-b7440f0db132/) |
+| 69 | Pressburg/Bratislava | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/f5f16f82-69c9-4779-9692-758ca6648d86/) |
+| 70 | Reschow | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/5f660e6d-0464-43e5-979d-cb3f7e816b32/) |
+| 71 | Schklov | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/3f1a6bc0-b8fa-417e-ad1f-17e44fb4f274/) |
+| 72 | Slawkowiec | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/1cad62ed-34c2-42b2-a6a3-a8080a4916ce/) |
+| 73 | TestCity | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/a2d4e128-acde-4488-aa54-e91377e5da5c/) |
+| 74 | Wamburg | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/e72d02c4-6ce4-47a4-90bb-bc5eefa19e57/) |
+| 75 | אבערראבבינער | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/8f93f0bf-4186-4353-a0b0-5acfce92bc5f/) |
+| 76 | אמשניץ | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/86002dcf-2bed-4f84-8a48-4ccc86cea6ba/) |
+| 77 | דיניויץ | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/d2e1f8ec-307f-4f91-bf5a-fbc773f5a9be/) |
+| 78 | ווערדין | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/0721c4fe-b21f-49ba-8c22-2e88972ac7eb/) |
+| 79 | ויעלקאשט | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/fb467505-f936-4ef7-b689-939005551f6a/) |
+| 80 | ולאטאווי | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/0208938d-3176-475c-8b48-d8343aa4aaa4/) |
+| 81 | זאמחוב | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/ae8f4639-0a49-4134-8218-71fac82176c1/) |
+| 82 | טורהאוויץ | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/b2bfe939-5b36-419e-82d3-7a50e931d253/) |
+| 83 | לעטשוב=לאצוב | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/e6e1e6d0-e5ed-44bd-ad45-80031dafb019/) |
+| 84 | נאווי דוואהר | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/77a30656-67d8-481b-803a-cbb42820e918/) |
+| 85 | סטאבנץ | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/b3953102-c7d6-4b30-aff2-73315442afa2/) |
+| 86 | קאסנטין הישנה | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/596f7a3f-e279-4719-81d4-d6c6a39a2135/) |
+| 87 | ראנינבורג | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/5d026843-a4a0-4a9d-8d48-c519076970aa/) |
+| 88 | שערשאווי | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/8375c608-fa73-49c6-84da-a9bb8fcf05a1/) |
+| 89 | שקוד האזפוט | — — | 0 | — | [edit](https://www.haskala-library.net/admin/snippets/home/city/edit/ddafbbdc-a731-4005-94a6-a3fcd31a59a2/) |


### PR DESCRIPTION
## Summary
Generated from \`docs/audits/wikidata_candidates.csv\` after the Phase 2 \`--apply\` run set \`wikidata_id\` on the 135 auto-confidence rows. The remaining 89 are in the manual bucket and need a human decision.

[docs/audits/manual_review_list.md](docs/audits/manual_review_list.md) carries one row per city with:
- best-candidate Wikidata link
- best-candidate score
- runner-up QID + score
- direct Wagtail snippet edit URL → \`/admin/snippets/home/city/edit/<uuid>/\`

Sorted by score DESC so the highest-confidence pending confirmations come first.

## Notable close-calls (top tail)

| City | Wikidata | Note |
|---|---|---|
| Königsberg | Q1829 (Kaliningrad) | historical → modern |
| Lissa | Q52892 (Leszno) | historical → modern |
| Reichenberg | Q146351 (Liberec) | historical → modern |
| Ofen | Q193478 (Buda) | German name → entity |
| Buda | Q193478 (Buda) | **same QID — merge candidate** |

## Zero-score tail (25 rows)
Wikidata returned nothing for these in any of en / de / he:
- 6 split / disambiguator names (Krossen an der Oder, Landsberg/Warthe, Pressburg/Bratislava, Mesritsch, Neuzedlisch, Reschow)
- 1 leftover smoke fixture (TestCity)
- 18 Yiddish / Hebrew small-town spellings

These need a different treatment — either set wikidata_id manually after a custom Wikidata search, or skip and accept the row stays unanchored.

## Workflow
1. Open the markdown file, work down the list top to bottom.
2. For each row whose best-candidate looks right, click the **edit** link and paste the QID into the \`wikidata_id\` field.
3. Once done, run \`python manage.py export_wikidata_quickstatements --upload\` to push the back-links.

## Test plan
- [ ] CI green
- [ ] Click one **edit** link, confirm it opens the right Wagtail page after login