### PR TITLE
chore(places): restore Brest + Polen city rows

### DIFF
--- a/home/migrations/0037_restore_brest_polen.py
+++ b/home/migrations/0037_restore_brest_polen.py
@@ -1,0 +1,65 @@
+"""
+Restore the two City rows the operator accidentally deleted during
+the Phase 2 manual-review pass, and anchor them to their Wikidata
+QIDs.
+
+  Brest  c6376e77-0fd9-428f-b73d-97551d6baaec  Q140147
+  Polen  45eaaa97-a334-4546-9c2c-cd1cd232a855  Q36
+
+Polen is semantically a country, not a city. It lives in the City
+table for now because the catalog has no separate Country model;
+a follow-up migration can promote it once that model exists. The
+``wikidata_id=Q36`` anchor makes the distinction explicit until
+then.
+
+Idempotent — both rows are created via update_or_create so a
+re-apply on a database where they already exist is a no-op.
+"""
+from __future__ import annotations
+
+from django.db import migrations
+
+
+RESTORES = [
+    {
+        "uuid": "c6376e77-0fd9-428f-b73d-97551d6baaec",
+        "name": "Brest",
+        "slug": "brest",
+        "wikidata_id": "Q140147",
+    },
+    {
+        "uuid": "45eaaa97-a334-4546-9c2c-cd1cd232a855",
+        "name": "Polen",
+        "slug": "polen",
+        "wikidata_id": "Q36",
+    },
+]
+
+
+def apply(apps, schema_editor):
+    City = apps.get_model("home", "City")
+    for row in RESTORES:
+        City.objects.update_or_create(
+            uuid=row["uuid"],
+            defaults={
+                "name": row["name"],
+                "slug": row["slug"],
+                "wikidata_id": row["wikidata_id"],
+                "live": True,
+            },
+        )
+
+
+def revert(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("home", "0036_remove_smoke_test_fixtures"),
+    ]
+
+    operations = [
+        migrations.RunPython(apply, revert),
+    ]


### PR DESCRIPTION
## Summary
Two City rows were hard-deleted during the Phase 2 manual-review pass and need to be put back so legacy FK refs that point at the original UUIDs keep resolving.

| Name | UUID | Wikidata |
|---|---|---|
| Brest | c6376e77-…1d6baaec | [Q140147](https://www.wikidata.org/wiki/Q140147) |
| Polen | 45eaaa97-…d5251dcf | [Q36](https://www.wikidata.org/wiki/Q36) |

**Polen is semantically a country, not a city.** It lives in the City table for now because the catalog has no separate Country model; the Q36 anchor records the distinction until a future Country model exists.

Migration uses \`update_or_create\` so re-applying on a DB where the rows already exist is a no-op.

## Test plan
- [x] CI green
- [x] /places/brest/ resolves
- [x] /places/polen/ resolves