### PR TITLE
feature(detail): edit-in-admin badge on every detail page

### DIFF
--- a/haskala/templates/books/_book_header.html
+++ b/haskala/templates/books/_book_header.html
@@ -48,5 +48,6 @@
                 aria-label="Copy permalink">
             <i class="bi bi-link-45deg"></i> Permalink
         </button>
+        {% include "partials/_edit_in_admin.html" with modelname="book" pk=book.pk %}
     </div>
 </header>

--- a/haskala/templates/occupations/occupation_detail_page.html
+++ b/haskala/templates/occupations/occupation_detail_page.html
@@ -16,7 +16,10 @@
                 <span>{{ occupation.name }}</span>
             </p>
 
-            <h1 class="occupation-header__title h2 mb-2">{{ occupation.name }}</h1>
+            <h1 class="occupation-header__title h2 mb-2">
+                {{ occupation.name }}
+                {% include "partials/_edit_in_admin.html" with modelname="occupation" pk=occupation.pk %}
+            </h1>
 
             <p class="occupation-header__stats text-muted mb-3">
                 {{ persons_with_occupation|length }} person{{ persons_with_occupation|length|pluralize }}

--- a/haskala/templates/partials/_edit_in_admin.html
+++ b/haskala/templates/partials/_edit_in_admin.html
@@ -1,0 +1,18 @@
+{% comment %}
+Edit-in-admin badge link shown to authenticated curators on the
+public detail pages. The Wagtail snippet admin URL pattern is
+``/admin/snippets/home/<modelname>/edit/<pk>/`` for every model
+registered as a snippet. Anonymous users see nothing.
+
+Required context:
+  app:        Wagtail app label (almost always "home").
+  modelname:  lower-case model name (e.g. "book", "city", "topic").
+  pk:         the row's primary key (UUID or int).
+{% endcomment %}
+{% if request.user.is_authenticated %}
+    <a class="badge text-bg-secondary edit-in-admin"
+       href="/admin/snippets/{{ app|default:'home' }}/{{ modelname }}/edit/{{ pk }}/"
+       title="Open this row in the Wagtail snippet admin">
+        <i class="bi bi-pencil-square"></i> Edit
+    </a>
+{% endif %}

--- a/haskala/templates/persons/_person_header.html
+++ b/haskala/templates/persons/_person_header.html
@@ -80,5 +80,6 @@
                 aria-label="Copy permalink">
             <i class="bi bi-link-45deg"></i> Permalink
         </button>
+        {% include "partials/_edit_in_admin.html" with modelname="person" pk=person.pk %}
     </div>
 </header>

--- a/haskala/templates/places/_place_header.html
+++ b/haskala/templates/places/_place_header.html
@@ -37,5 +37,6 @@
                 aria-label="Copy permalink">
             <i class="bi bi-link-45deg"></i> Permalink
         </button>
+        {% include "partials/_edit_in_admin.html" with modelname="city" pk=city.pk %}
     </div>
 </header>

--- a/haskala/templates/publishers/publisher_detail_page.html
+++ b/haskala/templates/publishers/publisher_detail_page.html
@@ -16,7 +16,10 @@
                 <span>{{ publisher.name }}</span>
             </p>
 
-            <h1 class="publisher-header__title h2 mb-2">{{ publisher.name }}</h1>
+            <h1 class="publisher-header__title h2 mb-2">
+                {{ publisher.name }}
+                {% include "partials/_edit_in_admin.html" with modelname="publisher" pk=publisher.pk %}
+            </h1>
 
             <p class="publisher-header__stats text-muted mb-3">
                 {{ books_published|length }} published

--- a/haskala/templates/series/series_detail_page.html
+++ b/haskala/templates/series/series_detail_page.html
@@ -16,7 +16,10 @@
                 <span>{{ series.name }}</span>
             </p>
 
-            <h1 class="series-header__title h2 mb-2">{{ series.name }}</h1>
+            <h1 class="series-header__title h2 mb-2">
+                {{ series.name }}
+                {% include "partials/_edit_in_admin.html" with modelname="series" pk=series.pk %}
+            </h1>
 
             <p class="series-header__stats text-muted mb-3">
                 {{ books_in_series|length }} book{{ books_in_series|length|pluralize }}

--- a/haskala/templates/topics/topic_detail_page.html
+++ b/haskala/templates/topics/topic_detail_page.html
@@ -16,7 +16,10 @@
                 <span>{{ topic.name }}</span>
             </p>
 
-            <h1 class="topic-header__title h2 mb-2">{{ topic.name }}</h1>
+            <h1 class="topic-header__title h2 mb-2">
+                {{ topic.name }}
+                {% include "partials/_edit_in_admin.html" with modelname="topic" pk=topic.pk %}
+            </h1>
 
             <p class="topic-header__stats text-muted mb-3">
                 {{ books_with_topic|length }} book{{ books_with_topic|length|pluralize }}


### PR DESCRIPTION
## Summary
When a curator is logged in, every public detail page now shows an **Edit** badge next to the other action chips. The badge links straight to the matching Wagtail snippet edit form. Anonymous visitors see nothing.

## Wired into
| Public URL | Admin target |
|---|---|
| /books/<slug>/ | /admin/snippets/home/book/edit/<pk>/ |
| /persons/<slug>/ | /admin/snippets/home/person/edit/<pk>/ |
| /places/<slug>/ | /admin/snippets/home/city/edit/<pk>/ |
| /topics/<slug>/ | /admin/snippets/home/topic/edit/<pk>/ |
| /occupations/<slug>/ | /admin/snippets/home/occupation/edit/<pk>/ |
| /publishers/<slug>/ | /admin/snippets/home/publisher/edit/<pk>/ |
| /series/<slug>/ | /admin/snippets/home/series/edit/<pk>/ |

The new partial \`templates/partials/_edit_in_admin.html\` takes \`modelname\` + \`pk\` as parameters and renders the badge. Future detail pages can pick it up with one \`{% include %}\` line.

## Test plan
- [x] CI green (42 tests still pass)
- [ ] Anonymous visit to /places/anklam/ shows no Edit chip
- [ ] Logged-in visit to /places/anklam/ shows Edit → clicks land on the City snippet edit form for Anklam