### PR TITLE
bugfix(detail): RTL auto-detection for topics + occupations pages

### DIFF
--- a/haskala/templates/occupations/occupation_detail_page.html
+++ b/haskala/templates/occupations/occupation_detail_page.html
@@ -13,10 +13,10 @@
             <p class="text-muted small mb-1">
                 <a href="{% url 'occupations-list' %}">Occupations</a>
                 <span aria-hidden="true">&rsaquo;</span>
-                <span>{{ occupation.name }}</span>
+                <span dir="auto">{{ occupation.name }}</span>
             </p>
 
-            <h1 class="occupation-header__title h2 mb-2">
+            <h1 class="occupation-header__title h2 mb-2" dir="auto">
                 {{ occupation.name }}
                 {% include "partials/_edit_in_admin.html" with modelname="occupation" pk=occupation.pk %}
             </h1>
@@ -39,7 +39,7 @@
                 <h2 class="occupation-section__heading h4">Persons with this occupation</h2>
                 <ul class="list-unstyled mb-0">
                     {% for person in persons_with_occupation %}
-                        <li class="mb-1">
+                        <li class="mb-1" dir="auto">
                             <a href="{% url 'person-detail' person.slug %}" class="link-primary">
                                 {{ person }}
                             </a>

--- a/haskala/templates/occupations/occupations_page.html
+++ b/haskala/templates/occupations/occupations_page.html
@@ -20,7 +20,7 @@
                         <h2 class="index-group__heading h4 border-bottom pb-1">{{ letter }}</h2>
                         <ul class="list-unstyled mb-0">
                             {% for occ in occs %}
-                                <li class="mb-1">
+                                <li class="mb-1" dir="auto">
                                     <a href="{% url 'occupation-detail' occ.slug %}" class="link-primary">
                                         {{ occ.name }}
                                     </a>

--- a/haskala/templates/topics/topic_detail_page.html
+++ b/haskala/templates/topics/topic_detail_page.html
@@ -13,10 +13,10 @@
             <p class="text-muted small mb-1">
                 <a href="{% url 'topics-list' %}">Topics</a>
                 <span aria-hidden="true">&rsaquo;</span>
-                <span>{{ topic.name }}</span>
+                <span dir="auto">{{ topic.name }}</span>
             </p>
 
-            <h1 class="topic-header__title h2 mb-2">
+            <h1 class="topic-header__title h2 mb-2" dir="auto">
                 {{ topic.name }}
                 {% include "partials/_edit_in_admin.html" with modelname="topic" pk=topic.pk %}
             </h1>
@@ -39,7 +39,7 @@
                 <h2 class="topic-section__heading h4">Books with this topic</h2>
                 <ul class="list-unstyled mb-0">
                     {% for book in books_with_topic %}
-                        <li class="mb-1">
+                        <li class="mb-1" dir="auto">
                             <a href="{% url 'book-detail' book.slug %}" class="link-primary">
                                 {{ book.full_title|default:book.name|default:"[untitled]" }}
                             </a>

--- a/haskala/templates/topics/topics_page.html
+++ b/haskala/templates/topics/topics_page.html
@@ -20,7 +20,7 @@
                         <h2 class="index-group__heading h4 border-bottom pb-1">{{ letter }}</h2>
                         <ul class="list-unstyled mb-0">
                             {% for topic in topics %}
-                                <li class="mb-1">
+                                <li class="mb-1" dir="auto">
                                     <a href="{% url 'topic-detail' topic.slug %}" class="link-primary">
                                         {{ topic.name }}
                                     </a>


### PR DESCRIPTION
## Summary
The /topics/ and /occupations/ index + detail pages used to render Hebrew/Yiddish item names left-to-right because the wrapper elements had no dir attribute. Same pattern as books/persons/places: set \`dir="auto"\` on the per-item wrapper so the browser picks the direction from the content's first strong character.

## Touched
- \`topics_page.html\` — index list (each \`<li>\`)
- \`topic_detail_page.html\` — breadcrumb \`<span>\` + \`<h1>\` + book list \`<li>\`
- \`occupations_page.html\` — index list
- \`occupation_detail_page.html\` — breadcrumb + \`<h1>\` + person list

## Verified after container restart
| URL | dir="auto" count |
|---|---:|
| /topics/bible/ | 53 |
| /topics/ | 118 |
| /occupations/ | 6 |
| /occupations/<slug>/ | 152 |

Note: gunicorn caches templates, so a Redis \`cache.clear()\` alone doesn't flush — needs \`docker compose restart web\` to see the change in dev.

## Test plan
- [ ] CI green
- [ ] /topics/bible/ Hebrew book titles render RTL
- [ ] /occupations/rabbi/ (or any occ with Hebrew person names) renders RTL