### PR TITLE
bugfix(detail): edit-in-admin as bottom-left FAB pointing at /dashboard/

### DIFF
--- a/haskala/static/scss/_layout.scss
+++ b/haskala/static/scss/_layout.scss
@@ -174,6 +174,48 @@ a:hover {
   }
 }
 
+// =====================================
+// Edit-in-admin floating action button
+// =====================================
+// Bottom-left counterpart to #scrollTopBtn for authenticated curators.
+// Only rendered server-side when request.user.is_authenticated, so
+// anonymous visitors never see it. Always visible (no scroll gate)
+// because curators expect the edit affordance on every detail page.
+
+.edit-in-admin-fab {
+  position: fixed;
+  left: 1.5rem;
+  bottom: 1.5rem;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background-color: $haskala-brown;
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    transform 0.2s ease;
+  z-index: 1050;
+
+  &:hover,
+  &:focus {
+    background-color: $haskala-blue;
+    color: #fff;
+    transform: translateY(-2px);
+    text-decoration: none;
+  }
+
+  i {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+}
+
 // Haskala Buttons (Bootstrap .btn-Klassen überschreiben)
 
 .btn {

--- a/haskala/templates/books/_book_header.html
+++ b/haskala/templates/books/_book_header.html
@@ -48,6 +48,5 @@
                 aria-label="Copy permalink">
             <i class="bi bi-link-45deg"></i> Permalink
         </button>
-        {% include "partials/_edit_in_admin.html" with modelname="book" pk=book.pk %}
     </div>
 </header>

--- a/haskala/templates/books/book_detail_page.html
+++ b/haskala/templates/books/book_detail_page.html
@@ -29,6 +29,7 @@
         {% include "books/_book_cite_modal.html" %}
         {% include "partials/_export_modal.html" with modal_id="book-export-modal" entity="book" slug=book.slug title=book.full_title|default:book.name %}
     </div>
+    {% include "partials/_edit_in_admin.html" with modelname="book" pk=book.pk %}
 {% endblock %}
 
 {% block extra_js %}

--- a/haskala/templates/occupations/occupation_detail_page.html
+++ b/haskala/templates/occupations/occupation_detail_page.html
@@ -13,10 +13,10 @@
             <p class="text-muted small mb-1">
                 <a href="{% url 'occupations-list' %}">Occupations</a>
                 <span aria-hidden="true">&rsaquo;</span>
-                <span>{{ occupation.name }}</span>
+                <span dir="auto">{{ occupation.name }}</span>
             </p>
 
-            <h1 class="occupation-header__title h2 mb-2">
+            <h1 class="occupation-header__title h2 mb-2" dir="auto">
                 {{ occupation.name }}
                 {% include "partials/_edit_in_admin.html" with modelname="occupation" pk=occupation.pk %}
             </h1>
@@ -39,7 +39,7 @@
                 <h2 class="occupation-section__heading h4">Persons with this occupation</h2>
                 <ul class="list-unstyled mb-0">
                     {% for person in persons_with_occupation %}
-                        <li class="mb-1">
+                        <li class="mb-1" dir="auto">
                             <a href="{% url 'person-detail' person.slug %}" class="link-primary">
                                 {{ person }}
                             </a>

--- a/haskala/templates/occupations/occupation_detail_page.html
+++ b/haskala/templates/occupations/occupation_detail_page.html
@@ -18,7 +18,6 @@
 
             <h1 class="occupation-header__title h2 mb-2" dir="auto">
                 {{ occupation.name }}
-                {% include "partials/_edit_in_admin.html" with modelname="occupation" pk=occupation.pk %}
             </h1>
 
             <p class="occupation-header__stats text-muted mb-3">
@@ -56,4 +55,5 @@
             <p class="text-muted">No persons linked to this occupation yet.</p>
         {% endif %}
     </div>
+    {% include "partials/_edit_in_admin.html" with modelname="occupation" pk=occupation.pk %}
 {% endblock %}

--- a/haskala/templates/occupations/occupations_page.html
+++ b/haskala/templates/occupations/occupations_page.html
@@ -20,7 +20,7 @@
                         <h2 class="index-group__heading h4 border-bottom pb-1">{{ letter }}</h2>
                         <ul class="list-unstyled mb-0">
                             {% for occ in occs %}
-                                <li class="mb-1">
+                                <li class="mb-1" dir="auto">
                                     <a href="{% url 'occupation-detail' occ.slug %}" class="link-primary">
                                         {{ occ.name }}
                                     </a>

--- a/haskala/templates/partials/_edit_in_admin.html
+++ b/haskala/templates/partials/_edit_in_admin.html
@@ -1,8 +1,9 @@
 {% comment %}
-Edit-in-admin badge link shown to authenticated curators on the
-public detail pages. The Wagtail snippet admin URL pattern is
-``/admin/snippets/home/<modelname>/edit/<pk>/`` for every model
-registered as a snippet. Anonymous users see nothing.
+Floating edit-in-admin button rendered bottom-left for authenticated
+curators, mirroring the bottom-right scrollTopBtn. Clicks lead to
+the Wagtail snippet edit form. Wagtail's admin lives at /dashboard/
+on this deployment, not /admin/ (which is reserved for Django's
+contrib.admin and was the source of the initial bad link).
 
 Required context:
   app:        Wagtail app label (almost always "home").
@@ -10,9 +11,11 @@ Required context:
   pk:         the row's primary key (UUID or int).
 {% endcomment %}
 {% if request.user.is_authenticated %}
-    <a class="badge text-bg-secondary edit-in-admin"
-       href="/admin/snippets/{{ app|default:'home' }}/{{ modelname }}/edit/{{ pk }}/"
-       title="Open this row in the Wagtail snippet admin">
-        <i class="bi bi-pencil-square"></i> Edit
+    <a id="editInAdminBtn"
+       class="edit-in-admin-fab"
+       href="/dashboard/snippets/{{ app|default:'home' }}/{{ modelname }}/edit/{{ pk }}/"
+       aria-label="Edit in admin"
+       title="Edit in admin">
+        <i class="bi bi-pencil-square"></i>
     </a>
 {% endif %}

--- a/haskala/templates/persons/_person_header.html
+++ b/haskala/templates/persons/_person_header.html
@@ -80,6 +80,5 @@
                 aria-label="Copy permalink">
             <i class="bi bi-link-45deg"></i> Permalink
         </button>
-        {% include "partials/_edit_in_admin.html" with modelname="person" pk=person.pk %}
     </div>
 </header>

--- a/haskala/templates/persons/person_detail_page.html
+++ b/haskala/templates/persons/person_detail_page.html
@@ -38,4 +38,5 @@
 
         {% include "partials/_export_modal.html" with modal_id="person-export-modal" entity="person" slug=person.slug title=person %}
     </div>
+    {% include "partials/_edit_in_admin.html" with modelname="person" pk=person.pk %}
 {% endblock %}

--- a/haskala/templates/places/_place_header.html
+++ b/haskala/templates/places/_place_header.html
@@ -37,6 +37,5 @@
                 aria-label="Copy permalink">
             <i class="bi bi-link-45deg"></i> Permalink
         </button>
-        {% include "partials/_edit_in_admin.html" with modelname="city" pk=city.pk %}
     </div>
 </header>

--- a/haskala/templates/places/place_detail_page.html
+++ b/haskala/templates/places/place_detail_page.html
@@ -36,4 +36,5 @@
 
         {% include "partials/_export_modal.html" with modal_id="place-export-modal" entity="place" slug=city.slug title=city.name %}
     </div>
+    {% include "partials/_edit_in_admin.html" with modelname="city" pk=city.pk %}
 {% endblock %}

--- a/haskala/templates/publishers/publisher_detail_page.html
+++ b/haskala/templates/publishers/publisher_detail_page.html
@@ -18,7 +18,6 @@
 
             <h1 class="publisher-header__title h2 mb-2">
                 {{ publisher.name }}
-                {% include "partials/_edit_in_admin.html" with modelname="publisher" pk=publisher.pk %}
             </h1>
 
             <p class="publisher-header__stats text-muted mb-3">
@@ -81,4 +80,5 @@
             <p class="text-muted">No books linked to this publisher yet.</p>
         {% endif %}
     </div>
+    {% include "partials/_edit_in_admin.html" with modelname="publisher" pk=publisher.pk %}
 {% endblock %}

--- a/haskala/templates/series/series_detail_page.html
+++ b/haskala/templates/series/series_detail_page.html
@@ -18,7 +18,6 @@
 
             <h1 class="series-header__title h2 mb-2">
                 {{ series.name }}
-                {% include "partials/_edit_in_admin.html" with modelname="series" pk=series.pk %}
             </h1>
 
             <p class="series-header__stats text-muted mb-3">
@@ -59,4 +58,5 @@
             <p class="text-muted">No books linked to this series yet.</p>
         {% endif %}
     </div>
+    {% include "partials/_edit_in_admin.html" with modelname="series" pk=series.pk %}
 {% endblock %}

--- a/haskala/templates/topics/topic_detail_page.html
+++ b/haskala/templates/topics/topic_detail_page.html
@@ -18,7 +18,6 @@
 
             <h1 class="topic-header__title h2 mb-2" dir="auto">
                 {{ topic.name }}
-                {% include "partials/_edit_in_admin.html" with modelname="topic" pk=topic.pk %}
             </h1>
 
             <p class="topic-header__stats text-muted mb-3">
@@ -56,4 +55,5 @@
             <p class="text-muted">No books for this topic yet.</p>
         {% endif %}
     </div>
+    {% include "partials/_edit_in_admin.html" with modelname="topic" pk=topic.pk %}
 {% endblock %}

--- a/haskala/templates/topics/topic_detail_page.html
+++ b/haskala/templates/topics/topic_detail_page.html
@@ -13,10 +13,10 @@
             <p class="text-muted small mb-1">
                 <a href="{% url 'topics-list' %}">Topics</a>
                 <span aria-hidden="true">&rsaquo;</span>
-                <span>{{ topic.name }}</span>
+                <span dir="auto">{{ topic.name }}</span>
             </p>
 
-            <h1 class="topic-header__title h2 mb-2">
+            <h1 class="topic-header__title h2 mb-2" dir="auto">
                 {{ topic.name }}
                 {% include "partials/_edit_in_admin.html" with modelname="topic" pk=topic.pk %}
             </h1>
@@ -39,7 +39,7 @@
                 <h2 class="topic-section__heading h4">Books with this topic</h2>
                 <ul class="list-unstyled mb-0">
                     {% for book in books_with_topic %}
-                        <li class="mb-1">
+                        <li class="mb-1" dir="auto">
                             <a href="{% url 'book-detail' book.slug %}" class="link-primary">
                                 {{ book.full_title|default:book.name|default:"[untitled]" }}
                             </a>

--- a/haskala/templates/topics/topics_page.html
+++ b/haskala/templates/topics/topics_page.html
@@ -20,7 +20,7 @@
                         <h2 class="index-group__heading h4 border-bottom pb-1">{{ letter }}</h2>
                         <ul class="list-unstyled mb-0">
                             {% for topic in topics %}
-                                <li class="mb-1">
+                                <li class="mb-1" dir="auto">
                                     <a href="{% url 'topic-detail' topic.slug %}" class="link-primary">
                                         {{ topic.name }}
                                     </a>


### PR DESCRIPTION
## Summary
PR #136 shipped the edit button as an inline badge in the action-chips row and pointed at \`/admin/snippets/...\`. Two issues surfaced after merge:

1. **Wrong URL prefix** — Wagtail's admin lives at \`/dashboard/\` on this deployment; \`/admin/\` is reserved for Django's contrib.admin and serves a different login page. Curators clicking the badge landed on a 404-shaped Django admin response.
2. **Wrong placement** — the inline badge got lost among the existing action chips (Cite / Export / Permalink). User asked for it next to the scroll-to-top button.

## Fixes
- URL pattern → \`/dashboard/snippets/<app>/<model>/edit/<pk>/\`
- Rendered as a **fixed-position floating action button at bottom-left**, mirroring the existing \`#scrollTopBtn\` at bottom-right. Same colours, shadow, hover.
- Anonymous visitors still see nothing (partial guards on \`request.user.is_authenticated\`).

## Files touched
- New SCSS: \`.edit-in-admin-fab\` block in \`_layout.scss\` (mirrors \`#scrollTopBtn\`); CSS bundle rebuilt via \`npm run build:css\`.
- Partial: \`_edit_in_admin.html\` now emits the FAB anchor instead of a badge.
- All 7 detail pages — moved the \`{% include %}\` from header chips into the bottom of \`{% block content %}\`.

## Test plan
- [ ] CI green
- [ ] Logged in: detail pages show a small pencil button bottom-left; clicking lands on the snippet edit form in Wagtail
- [ ] Anonymous: no button visible
- [ ] Mobile: button doesn't collide with bottom safe-area or scroll-top button