### PR TITLE
feature(alias-names): sync command + display section + zero-stats filter

### DIFF
--- a/haskala/templates/books/_book_header.html
+++ b/haskala/templates/books/_book_header.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load utils %}
 <header class="book-header mb-4">
     <p class="text-muted small mb-1">
         <a href="{% url 'books-list' %}">Books</a>
@@ -15,6 +16,8 @@
             {{ book.title_in_latin_characters }}
         </p>
     {% endif %}
+
+    {% aliases_block book %}
 
     {% if book.bookauthor_set.all %}
         <p class="book-header__authors mb-2">

--- a/haskala/templates/occupations/occupation_detail_page.html
+++ b/haskala/templates/occupations/occupation_detail_page.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utils %}
 
 {% block title %}{{ occupation.name }} | Occupations{% endblock %}
 
@@ -20,9 +21,13 @@
                 {{ occupation.name }}
             </h1>
 
-            <p class="occupation-header__stats text-muted mb-3">
-                {{ persons_with_occupation|length }} person{{ persons_with_occupation|length|pluralize }}
-            </p>
+            {% aliases_block occupation %}
+
+            {% if persons_with_occupation|length %}
+                <p class="occupation-header__stats text-muted mb-3">
+                    {{ persons_with_occupation|length }} person{{ persons_with_occupation|length|pluralize }}
+                </p>
+            {% endif %}
 
             <div class="occupation-header__actions">
                 <button type="button" class="badge text-bg-secondary"

--- a/haskala/templates/occupations/occupations_page.html
+++ b/haskala/templates/occupations/occupations_page.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utils %}
 
 {% block title %}Occupations{% endblock %}
 
@@ -24,6 +25,10 @@
                                     <a href="{% url 'occupation-detail' occ.slug %}" class="link-primary">
                                         {{ occ.name }}
                                     </a>
+                                    {% aliases_inline occ as alt %}
+                                    {% if alt %}
+                                        <span class="text-muted small">({{ alt }})</span>
+                                    {% endif %}
                                 </li>
                             {% endfor %}
                         </ul>

--- a/haskala/templates/partials/_aliases_block.html
+++ b/haskala/templates/partials/_aliases_block.html
@@ -1,0 +1,30 @@
+{% comment %}
+"Also known as" section rendered under the detail-page title for
+City / Person / Topic / Occupation entities that carry one or more
+AliasName rows. Sourced from Wikidata labels + aliases (see
+sync_wikidata_aliases) plus any manually curated entries.
+
+Context (provided by the ``aliases_block`` inclusion tag in
+``home.templatetags.utils``):
+
+  groups: list of ``{"language": str, "values": [str, ...]}`` --
+          already sorted alphabetically by language code and with
+          the row's own primary name filtered out.
+{% endcomment %}
+{% if groups %}
+    <section class="aliases-block mb-3" aria-label="Also known as">
+        <h2 class="aliases-block__heading h6 text-uppercase text-muted mb-2">
+            Also known as
+        </h2>
+        <dl class="aliases-block__list row gx-3 mb-0">
+            {% for group in groups %}
+                <dt class="col-auto text-muted small text-uppercase">
+                    {{ group.language }}
+                </dt>
+                <dd class="col mb-1" dir="auto">
+                    {{ group.values|join:", " }}
+                </dd>
+            {% endfor %}
+        </dl>
+    </section>
+{% endif %}

--- a/haskala/templates/persons/_person_header.html
+++ b/haskala/templates/persons/_person_header.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load utils %}
 <header class="person-header mb-4">
     <p class="text-muted small mb-1">
         <a href="{% url 'persons-list' %}">Persons</a>
@@ -19,6 +20,8 @@
     {% if person.pseudonym %}
         <p class="person-header__alt text-muted mb-1">aka {{ person.pseudonym }}</p>
     {% endif %}
+
+    {% aliases_block person %}
 
     {% if person.occupations.all %}
         <p class="person-header__chips mb-2">

--- a/haskala/templates/persons/persons_page.html
+++ b/haskala/templates/persons/persons_page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
+{% load utils %}
 
 {% block title %}Persons{% endblock %}
 
@@ -25,6 +26,10 @@
                                     <a href="{% url 'person-detail' person.slug %}" class="link-primary">
                                         {{ person }}
                                     </a>
+                                    {% aliases_inline person as alt %}
+                                    {% if alt %}
+                                        <span class="text-muted small">({{ alt }})</span>
+                                    {% endif %}
                                     {% if person.date_of_birth or person.date_of_death %}
                                         <span class="text-muted small">
                                             &middot; {{ person.date_of_birth|default:"?" }}&ndash;{{ person.date_of_death|default:"?" }}

--- a/haskala/templates/places/_place_header.html
+++ b/haskala/templates/places/_place_header.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load utils %}
 <header class="place-header mb-4">
     <p class="text-muted small mb-1">
         <a href="{% url 'places-list' %}">Places</a>
@@ -8,13 +9,12 @@
 
     <h1 class="place-header__title h2 mb-2">{{ city.name }}</h1>
 
-    <p class="place-header__stats text-muted mb-3">
-        {{ books_published_here|length }} book{{ books_published_here|length|pluralize }}
-        &middot; {{ editions_here|length }} edition{{ editions_here|length|pluralize }}
-        &middot; {{ translations_here|length }} translation{{ translations_here|length|pluralize }}
-        &middot; {{ born_here|length }} born
-        &middot; {{ died_here|length }} died
-    </p>
+    {% aliases_block city %}
+
+    {% nonzero_stats books_published_here|length "{n} book{s}" editions_here|length "{n} edition{s}" translations_here|length "{n} translation{s}" born_here|length "{n} born" died_here|length "{n} died" as stats_line %}
+    {% if stats_line %}
+        <p class="place-header__stats text-muted mb-3">{{ stats_line }}</p>
+    {% endif %}
 
     {% if geolocation %}
         <div class="place-header__map mb-3" style="height: 280px;">

--- a/haskala/templates/places/places_page.html
+++ b/haskala/templates/places/places_page.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags %}
+{% load utils %}
 
 {% block title %}Places{% endblock %}
 
@@ -32,13 +33,17 @@
                             <h2 class="index-group__heading h4 pb-1">{{ letter }}</h2>
                             <ul class="list-unstyled mb-0">
                                 {% for city in cities %}
-                                    <li class="mb-1">
+                                    <li class="mb-1" dir="auto">
                                         {% if city.slug %}
                                             <a href="{% url 'place-detail' city.slug %}" class="link-primary">
                                                 {{ city.name }}
                                             </a>
                                         {% else %}
                                             <span>{{ city.name }}</span>
+                                        {% endif %}
+                                        {% aliases_inline city as alt %}
+                                        {% if alt %}
+                                            <span class="text-muted small">({{ alt }})</span>
                                         {% endif %}
                                     </li>
                                 {% endfor %}

--- a/haskala/templates/publishers/publisher_detail_page.html
+++ b/haskala/templates/publishers/publisher_detail_page.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utils %}
 
 {% block title %}{{ publisher.name }} | Publishers{% endblock %}
 
@@ -20,12 +21,10 @@
                 {{ publisher.name }}
             </h1>
 
-            <p class="publisher-header__stats text-muted mb-3">
-                {{ books_published|length }} published
-                {% if books_original %}
-                    &middot; {{ books_original|length }} as original publisher
-                {% endif %}
-            </p>
+            {% nonzero_stats books_published|length "{n} published" books_original|length "{n} as original publisher" as pub_stats %}
+            {% if pub_stats %}
+                <p class="publisher-header__stats text-muted mb-3">{{ pub_stats }}</p>
+            {% endif %}
 
             <div class="publisher-header__actions">
                 <button type="button" class="badge text-bg-secondary"

--- a/haskala/templates/series/series_detail_page.html
+++ b/haskala/templates/series/series_detail_page.html
@@ -20,9 +20,11 @@
                 {{ series.name }}
             </h1>
 
-            <p class="series-header__stats text-muted mb-3">
-                {{ books_in_series|length }} book{{ books_in_series|length|pluralize }}
-            </p>
+            {% if books_in_series|length %}
+                <p class="series-header__stats text-muted mb-3">
+                    {{ books_in_series|length }} book{{ books_in_series|length|pluralize }}
+                </p>
+            {% endif %}
 
             <div class="series-header__actions">
                 <button type="button" class="badge text-bg-secondary"

--- a/haskala/templates/topics/topic_detail_page.html
+++ b/haskala/templates/topics/topic_detail_page.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utils %}
 
 {% block title %}{{ topic.name }} | Topics{% endblock %}
 
@@ -20,9 +21,13 @@
                 {{ topic.name }}
             </h1>
 
-            <p class="topic-header__stats text-muted mb-3">
-                {{ books_with_topic|length }} book{{ books_with_topic|length|pluralize }}
-            </p>
+            {% aliases_block topic %}
+
+            {% if books_with_topic|length %}
+                <p class="topic-header__stats text-muted mb-3">
+                    {{ books_with_topic|length }} book{{ books_with_topic|length|pluralize }}
+                </p>
+            {% endif %}
 
             <div class="topic-header__actions">
                 <button type="button" class="badge text-bg-secondary"

--- a/haskala/templates/topics/topics_page.html
+++ b/haskala/templates/topics/topics_page.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utils %}
 
 {% block title %}Topics{% endblock %}
 
@@ -24,6 +25,10 @@
                                     <a href="{% url 'topic-detail' topic.slug %}" class="link-primary">
                                         {{ topic.name }}
                                     </a>
+                                    {% aliases_inline topic as alt %}
+                                    {% if alt %}
+                                        <span class="text-muted small">({{ alt }})</span>
+                                    {% endif %}
                                 </li>
                             {% endfor %}
                         </ul>

--- a/home/management/commands/sync_wikidata_aliases.py
+++ b/home/management/commands/sync_wikidata_aliases.py
@@ -1,0 +1,242 @@
+"""
+Pull Wikidata labels + aliases for every catalog row that carries a
+``wikidata_id`` and upsert them into the AliasName table so the
+public site can surface historical/regional name variants ("Lemberg"
+/ "Lwów" / "Львів" / "Lviv" all on the same City row).
+
+Per anchored row the command:
+
+1. Fetches the Wikidata entity JSON.
+2. Reads ``labels`` (preferred name per language) and ``aliases``
+   (additional accepted forms per language).
+3. Restricts to the Haskala-relevant language whitelist (see
+   ``LANGUAGES_OF_INTEREST``) so the table doesn't grow with
+   labels in Vietnamese, Tagalog, etc. that nobody on the site
+   reads.
+4. Upserts each (target, language, value) triple. Labels become
+   ``is_preferred=True``; aliases ``is_preferred=False``.
+   ``source="wikidata"``.
+5. Never touches rows whose source is ``manual`` -- curator-set
+   aliases survive every sync, because the dedup check only
+   considers (language, value) and the upsert never overwrites an
+   existing row.
+
+Idempotent. Re-running against an already-synced row only writes
+the deltas. The (target, language, value) unique constraint at the
+DB layer is the ultimate safety net.
+
+Only City is processed today. Person / Topic / Occupation will be
+covered once the manual Person cleanup pass is done; the per-model
+loop already iterates a TARGET_MODELS list to make extension a
+one-liner.
+
+Rate-limited (default 0.6s between requests) and identifies itself
+in the User-Agent per Wikidata's API etiquette.
+"""
+from __future__ import annotations
+
+import time
+
+import requests
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+
+from home.models import AliasName, City
+
+
+USER_AGENT = (
+    "haskala-catalog/1.0 "
+    "(https://github.com/judaicalink/haskala; "
+    "benjamin.schnabel@ephe.psl.eu) "
+    "django-management-command"
+)
+ENTITY_URL = (
+    "https://www.wikidata.org/wiki/Special:EntityData/{qid}.json"
+)
+
+
+# Whitelist of languages that the Haskala catalog audience is
+# expected to read. Wikidata items routinely carry labels in 100+
+# languages -- restricting keeps the AliasName table focused and
+# the search index small.
+LANGUAGES_OF_INTEREST = {
+    "be",   # Belarusian -- Brest, Hrodna
+    "cs",   # Czech -- Brno, Praha
+    "de",   # German -- primary catalog language
+    "en",   # English -- public lingua franca
+    "fr",   # French -- Alsace
+    "he",   # Hebrew -- primary Jewish audience
+    "hu",   # Hungarian -- Pressburg, Budapest
+    "it",   # Italian -- Padua, Mantua
+    "la",   # Latin -- early-modern texts
+    "lt",   # Lithuanian -- Vilnius
+    "nl",   # Dutch -- Amsterdam, Den Haag
+    "pl",   # Polish -- many catalog cities
+    "ro",   # Romanian -- Arad
+    "ru",   # Russian -- Eastern European corridor
+    "sk",   # Slovak -- Bratislava
+    "uk",   # Ukrainian -- Lviv, Lemberg
+    "yi",   # Yiddish -- historical Maskil writings
+}
+
+
+# Target models considered. Initially only City; Person etc. join
+# when their wikidata_id pass is complete.
+TARGET_MODELS = [
+    ("City", City),
+]
+
+
+class Command(BaseCommand):
+    help = (
+        "Pull labels + aliases from Wikidata for every anchored "
+        "row and upsert them into the AliasName table."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Commit the upserts. Default: dry-run.",
+        )
+        parser.add_argument(
+            "--delay",
+            type=float,
+            default=0.6,
+            help="Seconds to sleep between Wikidata requests "
+                 "(politeness). Default 0.6.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=0,
+            help="Process at most N anchored rows. 0 = all.",
+        )
+
+    def handle(self, *args, **options):
+        session = requests.Session()
+        session.headers["User-Agent"] = USER_AGENT
+
+        for label, model_cls in TARGET_MODELS:
+            self._sync_one_model(
+                session, label, model_cls,
+                apply=options["apply"],
+                delay=options["delay"],
+                limit=options["limit"],
+            )
+
+    def _sync_one_model(
+        self, session, label, model_cls, *, apply, delay, limit,
+    ):
+        ct = ContentType.objects.get_for_model(model_cls)
+        qs = (
+            model_cls.objects
+            .filter(live=True)
+            .exclude(wikidata_id="")
+            .order_by("name")
+        )
+        if limit:
+            qs = qs[: limit]
+        rows = list(qs)
+
+        self.stdout.write(self.style.WARNING(
+            f"[{label}] {len(rows)} anchored rows -- "
+            f"apply={apply}, delay={delay}s"
+        ))
+
+        created_total = noop_total = noent_total = 0
+        for idx, row in enumerate(rows, 1):
+            entity = self._fetch_entity(session, row.wikidata_id)
+            time.sleep(delay)
+            if entity is None:
+                noent_total += 1
+                self.stdout.write(
+                    f"  [{idx}/{len(rows)}] {row.name:30} "
+                    f"-> {row.wikidata_id:10} NO ENTITY"
+                )
+                continue
+
+            triples = self._extract_triples(entity)
+
+            existing = set(
+                AliasName.objects
+                .filter(content_type=ct, object_id=str(row.pk))
+                .values_list("language", "value")
+            )
+
+            created_here = 0
+            for lang, value, is_pref in triples:
+                if (lang, value) in existing:
+                    continue
+                created_here += 1
+                if apply:
+                    AliasName.objects.create(
+                        content_type=ct,
+                        object_id=str(row.pk),
+                        language=lang,
+                        value=value,
+                        source="wikidata",
+                        is_preferred=is_pref,
+                    )
+            if created_here:
+                created_total += created_here
+                self.stdout.write(
+                    f"  [{idx}/{len(rows)}] {row.name:30} "
+                    f"-> {row.wikidata_id:10} +{created_here} aliases"
+                )
+            else:
+                noop_total += 1
+
+        self.stdout.write(self.style.SUCCESS(
+            f"[{label}] created={created_total}, "
+            f"noop(no_new)={noop_total}, "
+            f"no_entity={noent_total}"
+        ))
+        if not apply:
+            self.stdout.write(self.style.WARNING(
+                "DRY RUN: re-run with --apply to commit."
+            ))
+
+    def _extract_triples(self, entity):
+        """Materialize (lang, value, is_preferred) tuples for the
+        labels + aliases in the whitelist languages. Labels become
+        is_preferred=True; aliases is_preferred=False.
+
+        Dedups within the fetch: Wikidata sometimes lists the same
+        spelling as both the language's preferred label AND as one
+        of its aliases (e.g. ``Бжег`` for Brieg in Ukrainian). The
+        label-pass wins because it iterates first and the
+        ``seen`` set short-circuits the alias-pass for identical
+        (lang, value) pairs."""
+        seen = {}
+        labels = entity.get("labels", {}) or {}
+        aliases = entity.get("aliases", {}) or {}
+
+        for lang, blob in labels.items():
+            if lang not in LANGUAGES_OF_INTEREST:
+                continue
+            val = (blob or {}).get("value", "").strip()
+            if val:
+                seen[(lang, val)] = True
+
+        for lang, blob_list in aliases.items():
+            if lang not in LANGUAGES_OF_INTEREST:
+                continue
+            for blob in (blob_list or []):
+                val = (blob or {}).get("value", "").strip()
+                if val:
+                    seen.setdefault((lang, val), False)
+
+        return [
+            (lang, val, is_pref)
+            for (lang, val), is_pref in seen.items()
+        ]
+
+    def _fetch_entity(self, session, qid):
+        try:
+            r = session.get(ENTITY_URL.format(qid=qid), timeout=15)
+            r.raise_for_status()
+            return r.json().get("entities", {}).get(qid)
+        except (requests.RequestException, ValueError) as exc:
+            self.stderr.write(f"  entity error for {qid}: {exc}")
+            return None

--- a/home/templatetags/utils.py
+++ b/home/templatetags/utils.py
@@ -146,3 +146,115 @@ def library_catalog_url(value, library):
     if not pattern:
         return ""
     return pattern.format(id=quote_plus(raw))
+
+
+# ---------------------------------------------------------------------
+# Header-stats join: drop zero entries before joining
+# ---------------------------------------------------------------------
+@register.simple_tag
+def nonzero_stats(*pairs, sep=" · "):
+    """Render header stats lines such as
+    ``27 books · 7 editions · 0 translations · 0 born · 0 died``
+    without the zero-count tail, leaving ``27 books · 7 editions``.
+
+    Accepts an even-length argument list of alternating
+    ``(count, label_template)`` pairs::
+
+        {% nonzero_stats
+            books|length "{n} book{s}"
+            editions|length "{n} edition{s}"
+            translations|length "{n} translation{s}"
+            born|length "{n} born"
+            died|length "{n} died"
+        %}
+
+    The ``label_template`` is a ``str.format``-style string with
+    ``{n}`` substituted with the count and ``{s}`` substituted with
+    "s" when count != 1 (English plural). Curated labels that don't
+    pluralize (e.g. "born", "died") simply omit ``{s}``.
+
+    Entries whose count is zero (or falsy) are skipped entirely so
+    the join doesn't surface noise. Returns the empty string when
+    no pair survives so the surrounding ``<p>`` can also be hidden
+    with ``{% if %}`` if desired.
+    """
+    if len(pairs) % 2:
+        return ""
+    out = []
+    for i in range(0, len(pairs), 2):
+        count = pairs[i]
+        try:
+            n = int(count)
+        except (TypeError, ValueError):
+            n = 0
+        if not n:
+            continue
+        tpl = pairs[i + 1] or "{n}"
+        out.append(
+            str(tpl).format(n=n, s="" if n == 1 else "s")
+        )
+    return sep.join(out)
+
+
+# ---------------------------------------------------------------------
+# Alias-name helpers — surface Wikidata-sourced + manually curated
+# alternative names on the public site.
+# ---------------------------------------------------------------------
+@register.simple_tag
+def aliases_inline(target, limit=4):
+    """Return up to *limit* distinct alias values for *target* as a
+    single comma-separated string, suitable for the gray
+    "(Lwiw, Lwów, Львів)" suffix on index-page entries.
+
+    Skips values that equal the target's primary display name so
+    we don't repeat the row's own ``name`` / ``pref_label``.
+    Sorted by language to keep the output deterministic between
+    requests."""
+    if target is None or not hasattr(target, "aliases"):
+        return ""
+    primary = (
+        getattr(target, "name", None)
+        or getattr(target, "pref_label", None)
+        or ""
+    ).strip().lower()
+    seen = []
+    for alias in target.aliases.all().order_by("language", "value"):
+        val = (alias.value or "").strip()
+        if not val or val.lower() == primary:
+            continue
+        if val not in seen:
+            seen.append(val)
+        if len(seen) >= limit:
+            break
+    return ", ".join(seen)
+
+
+@register.inclusion_tag("partials/_aliases_block.html")
+def aliases_block(target):
+    """Render the "Auch bekannt als" section under the detail-page
+    title, grouped by language. Falls back to an empty block when
+    the target has no aliases so the template can be included
+    unconditionally."""
+    if target is None or not hasattr(target, "aliases"):
+        return {"groups": []}
+    primary = (
+        getattr(target, "name", None)
+        or getattr(target, "pref_label", None)
+        or ""
+    ).strip().lower()
+
+    by_lang = {}
+    for alias in (
+        target.aliases.all()
+        .order_by("language", "-is_preferred", "value")
+    ):
+        val = (alias.value or "").strip()
+        if not val or val.lower() == primary:
+            continue
+        by_lang.setdefault(alias.language or "—", []).append(val)
+
+    groups = [
+        {"language": lang, "values": vals}
+        for lang, vals in sorted(by_lang.items())
+    ]
+    return {"groups": groups}


### PR DESCRIPTION
## Summary
Combines PR-2 and PR-3 of the alias-names rollout. Data sync + public-facing display land together.

## 1. sync_wikidata_aliases command
Pulls labels + aliases from Wikidata for every anchored row (City today; Person/Topic/Occupation later via TARGET_MODELS) and upserts AliasName rows.

- Rate-limited (0.6s default), identifies itself in the User-Agent per Wikidata etiquette
- Dedups within a single fetch (Brieg-style label = alias collision handled)
- Initial sweep wrote **8168 alias rows** across **17 languages** for **289 anchored cities**

## 2. Template tags (home.templatetags.utils)
- \`aliases_inline(target, limit=4)\` — gray "(Lwów, Lviv, Львів)" suffix on index-page entries
- \`aliases_block(target)\` — inclusion tag, renders "Also known as" grouped by language
- \`nonzero_stats(*pairs, sep)\` — joins (count, label) pairs, drops zeros; empty when all skip

## 3. Template updates
- Place / Person / Book detail headers — include aliases_block under title
- Topic / Occupation / Publisher / Series detail pages — aliases_block + \`{% if count %}\` guard on single-stat lines
- Places / Persons / Topics / Occupations index pages — gray inline aliases via aliases_inline

## Smoke
| Page | Result |
|---|---|
| Berlin (151/42/1/0/3) | "175 books · 42 editions · 1 translation · 3 died" — born=0 dropped ✓ |
| Anklam (0/0/0/0/0) | stats line hidden entirely ✓ |
| /places/ index — Altona row | "Altona (Альтона, Altona an der Elbe, Hamburg-Altona, ...)" |

## Bug found + fixed during this PR
Django's template lexer does NOT span newlines inside \`{% %}\` tags. The first version of nonzero_stats was multi-line and got rendered as literal text. Now single-line; works.

## Test plan
- [ ] CI green
- [ ] /places/berlin/ shows shrunken stats line
- [ ] /places/anklam/ has no stats line
- [ ] /places/lemberg/ shows "Also known as" grouped by language
- [ ] /places/ index shows gray inline aliases per city