### PR TITLE
feature(alias-names): accordion display + cross-language search

### DIFF
--- a/haskala/templates/partials/_aliases_block.html
+++ b/haskala/templates/partials/_aliases_block.html
@@ -1,33 +1,78 @@
 {% comment %}
-"Also known as" block rendered under the detail-page title for
+"Also known as" accordion rendered under the detail-page title for
 City / Person / Topic / Occupation entities with one or more
-AliasName rows. The catalog row's own name shown in the page H1
-acts as the implicit Default anchor; this block lists the four
-audience-relevant translations (EN, DE, HE, YI) in that fixed
-order, skipping any whose preferred label matches the H1 to avoid
-echo. Per language the preferred label leads, followed by any
-additional aliases for that language separated by commas.
+AliasName rows for the audience-facing languages (EN, DE, HE, YI).
+
+One accordion item per language: the header shows
+``Sprache | Primary`` (language code on the left, canonical label
+on the right plus a "+N variants" hint when applicable), the
+collapsed body lists every spelling for that language in
+preferred-first order separated by commas.
 
 Context (provided by the ``aliases_block`` inclusion tag in
 ``home.templatetags.utils``):
 
-  rows: list of ``{"language": iso, "values": [str, ...]}`` --
-        already filtered and ordered en, de, he, yi.
+  rows: list of {
+          language: ISO code,
+          primary:  canonical label for that language,
+          values:   [str, ...] all spellings for that language,
+          extras:   len(values) - 1,
+        }
+  instance_id: per-target slug used to scope the accordion's DOM
+               ids so multiple aliases_block calls on one page
+               don't collide.
 {% endcomment %}
 {% if rows %}
     <section class="aliases-block mb-3" aria-label="Also known as">
         <h2 class="aliases-block__heading h6 text-uppercase text-muted mb-2">
             Also known as
         </h2>
-        <dl class="aliases-block__list row gx-3 mb-0">
+        <div class="accordion accordion-flush"
+             id="{{ instance_id|default:'aliases-accordion' }}">
             {% for row in rows %}
-                <dt class="col-auto text-muted small text-uppercase">
-                    {{ row.language }}
-                </dt>
-                <dd class="col mb-1" dir="auto">
-                    {{ row.values|join:", " }}
-                </dd>
+                {% if row.extras %}
+                    {# Multiple values for this language -> collapsible #}
+                    <div class="accordion-item">
+                        <h3 class="accordion-header"
+                            id="{{ instance_id }}-h-{{ forloop.counter }}">
+                            <button class="accordion-button collapsed py-2"
+                                    type="button"
+                                    data-bs-toggle="collapse"
+                                    data-bs-target="#{{ instance_id }}-b-{{ forloop.counter }}"
+                                    aria-expanded="false"
+                                    aria-controls="{{ instance_id }}-b-{{ forloop.counter }}">
+                                <span class="text-muted small text-uppercase me-3"
+                                      style="min-width: 2.5rem;">
+                                    {{ row.language }}
+                                </span>
+                                <span dir="auto">{{ row.primary }}</span>
+                                <span class="text-muted small ms-2">
+                                    +{{ row.extras }}
+                                    variant{{ row.extras|pluralize }}
+                                </span>
+                            </button>
+                        </h3>
+                        <div id="{{ instance_id }}-b-{{ forloop.counter }}"
+                             class="accordion-collapse collapse"
+                             aria-labelledby="{{ instance_id }}-h-{{ forloop.counter }}">
+                            <div class="accordion-body py-2" dir="auto">
+                                {{ row.values|slice:"1:"|join:", " }}
+                            </div>
+                        </div>
+                    </div>
+                {% else %}
+                    {# Single value -> flat row, no collapse #}
+                    <div class="accordion-item">
+                        <div class="d-flex align-items-center py-2 px-3">
+                            <span class="text-muted small text-uppercase me-3"
+                                  style="min-width: 2.5rem;">
+                                {{ row.language }}
+                            </span>
+                            <span dir="auto">{{ row.primary }}</span>
+                        </div>
+                    </div>
+                {% endif %}
             {% endfor %}
-        </dl>
+        </div>
     </section>
 {% endif %}

--- a/home/templatetags/utils.py
+++ b/home/templatetags/utils.py
@@ -270,21 +270,20 @@ def aliases_inline(target):
 @register.inclusion_tag("partials/_aliases_block.html")
 def aliases_block(target):
     """Render the "Also known as" section under the detail-page
-    title as a flat one-line-per-language list.
+    title as a Bootstrap accordion. One accordion item per
+    language in ``DETAIL_BLOCK_LANGUAGES`` (en, de, he, yi). The
+    header shows ``Sprache | Primary`` (language code + the
+    canonical label for that language). The collapsed body lists
+    every spelling for that language in preferred-first order so
+    curators / readers can quickly scan all known variants.
 
-    Order: ``DETAIL_BLOCK_LANGUAGES`` (en, de, he, yi). The catalog
-    row's own name acts as the implicit "Default" anchor displayed
-    above this block (the H1), so when one of the four languages'
-    preferred label equals that primary name we skip the row to
-    avoid surfacing the same spelling twice.
+    The catalog row's own name (H1 above) is the implicit Default
+    anchor; when a language's preferred label equals it we skip
+    the whole language to avoid echo.
 
-    Per language we emit the preferred label first followed by any
-    additional aliases for that language, deduped and joined with
-    commas.
-
-    Returns ``{"rows": []}`` when no row survives so the template
-    can be included unconditionally and won't render a stray empty
-    <section>."""
+    Returns ``{"rows": [], "instance_id": ""}`` when no row
+    survives so the template can be included unconditionally and
+    won't render an empty <section>."""
     if target is None or not hasattr(target, "aliases"):
         return {"rows": []}
     primary = _target_primary(target)
@@ -311,15 +310,12 @@ def aliases_block(target):
             continue
         # All-or-nothing per language: if the preferred label
         # (first entry) equals the catalog row's own name, skip
-        # the whole language. We don't want to surface stray
-        # ``Germany`` / ``DE-BE`` aliases that Wikidata attaches
-        # to Q64's English entry just because the English label
-        # itself is "Berlin", same as ours.
+        # the whole language. Otherwise dedupe within the
+        # language, preserving preferred-first order. Drop any
+        # later entry that happens to equal the catalog primary
+        # too (rare but possible).
         if raw_values[0].lower() == primary_lower:
             continue
-        # Dedupe within the language, preserving preferred-first
-        # order. Drop any later entry that happens to equal the
-        # catalog primary too (rare but possible).
         seen, kept = set(), []
         for v in raw_values:
             if v.lower() == primary_lower or v in seen:
@@ -327,6 +323,16 @@ def aliases_block(target):
             seen.add(v)
             kept.append(v)
         if kept:
-            rows.append({"language": lang, "values": kept})
+            rows.append({
+                "language": lang,
+                "primary": kept[0],
+                "values": kept,
+                "extras": len(kept) - 1,
+            })
 
-    return {"rows": rows}
+    return {
+        "rows": rows,
+        "instance_id": (
+            f"aliases-{getattr(target, 'pk', '')}".replace('-', '')
+        ),
+    }

--- a/home/views.py
+++ b/home/views.py
@@ -413,6 +413,32 @@ def _text_field_q(q, model_cls, extra_paths=()):
     return q_obj
 
 
+def _alias_matching_pks(model_cls, q):
+    """Return the PKs of *model_cls* rows that have at least one
+    ``AliasName`` whose value matches *q* (case-insensitive
+    substring). Used by ``search_view`` so a user typing
+    ``Lwiw`` / ``Львів`` / ``לבוב`` finds the catalog row for
+    Lemberg even when the row's own primary name doesn't carry
+    the spelling. All 17 synced languages participate -- the
+    display-side ``DETAIL_BLOCK_LANGUAGES`` filter does NOT
+    restrict search.
+
+    Returns a Python ``set`` of strings (the UUID/int PKs as
+    stored in ``AliasName.object_id``). Materialising avoids the
+    Postgres "operator does not exist: uuid = character varying"
+    error that fires when a UUID-pk model gets a CharField
+    subquery handed straight to ``pk__in``."""
+    from .models import AliasName  # local import to dodge a cycle
+    from django.contrib.contenttypes.models import ContentType
+
+    ct = ContentType.objects.get_for_model(model_cls)
+    return set(
+        AliasName.objects
+        .filter(content_type=ct, value__icontains=q)
+        .values_list("object_id", flat=True)
+    )
+
+
 @cache_page(60 * 5)
 def search_view(request):
     """
@@ -450,17 +476,30 @@ def search_view(request):
     # columns, primary keys, slug fields, and ``legacy_language``
     # tokens; Book also gets the author M2M traversal paths.
     if q:
+        # Alias matches are added on top of the column-level
+        # text match so all 17 synced languages are searchable
+        # even when the row's own ``name`` / ``pref_label`` only
+        # carries one spelling. PKs come back as strings (UUIDs
+        # serialised in object_id) — Django's __in coerces.
+        book_alias_pks = _alias_matching_pks(Book, q)
+        person_alias_pks = _alias_matching_pks(Person, q)
+        city_alias_pks = _alias_matching_pks(City, q)
+
         books_qs = books_qs.filter(
             _text_field_q(q, Book, extra_paths=(
                 "authors__pref_label",
                 "authors__german_name",
                 "authors__hebrew_name",
-            ))
+            )) | Q(pk__in=book_alias_pks)
         ).distinct()
 
-        persons_qs = persons_qs.filter(_text_field_q(q, Person)).distinct()
+        persons_qs = persons_qs.filter(
+            _text_field_q(q, Person) | Q(pk__in=person_alias_pks)
+        ).distinct()
 
-        places_qs = places_qs.filter(_text_field_q(q, City))
+        places_qs = places_qs.filter(
+            _text_field_q(q, City) | Q(pk__in=city_alias_pks)
+        )
 
     # --- Advanced filters for books only ------------------------------------
     # Year range (gregorian_year)


### PR DESCRIPTION
## Summary
Two follow-ups on the AliasName rollout:

### 1. Detail-page accordion (revised)
- One Bootstrap accordion item per language (en, de, he, yi)
- Header: \`Sprache | Primary\` (language code left, canonical label right)
- **If only one alias**: flat row, no collapse, no "+0 variants" hint
- **If multiple aliases**: header shows primary, collapsed body shows ONLY the additional variants (no longer doubles the primary)

### 2. Cross-language search
All 17 synced languages now searchable. \`search_view\` joins the \`AliasName\` table by content type + value icontains.

| Query | Match |
|---|---|
| Lviv | Lemberg + Lviv |
| Wrocław | Breslau |
| Brno | Brno + Brünn |
| Pressburg | Pressburg/Bratislava |
| Львів (Ukrainian) | Lemberg + Lviv |
| לבוב (Hebrew) | Lemberg + Lviv |

### Bug found + fixed during this PR
Handing AliasName's CharField subquery straight to \`pk__in\` on a UUID-pk model triggered Postgres "operator does not exist: uuid = character varying". Materialising the queryset to a Python \`set\` of strings forces Django to coerce.

## Test plan
- [ ] CI green
- [ ] /places/lemberg/ shows accordion: en (Lviv + 2 variants), he (לביב + 3), yi (לעמבערג + 3); de skipped because matches default
- [ ] /search/?q=Lwów shows Lemberg in the results