### PR TITLE
bugfix(cookies): cookie banner z-index above maps + frontpage boxes

### DIFF
--- a/haskala/static/scss/_overrides.scss
+++ b/haskala/static/scss/_overrides.scss
@@ -784,3 +784,11 @@ table {
     padding-left: 1.5rem; /* sichert konsistente Abstände */
     list-style-position: outside;
 }
+
+// Cookie banner -- vanilla django-cookiebanner template ships
+// without z-index, so Leaflet map panes on /places/ and the
+// frontpage box stack overlay it. 9999 lifts the banner above
+// every other element on the page until the user has decided.
+#cookiebannerModal {
+  z-index: 9999;
+}


### PR DESCRIPTION
## Summary
The vanilla django-cookiebanner template ships HTML hooks but no CSS, so the banner's z-index falls back to \`auto\` and ends up beneath:

- the Leaflet map panes on \`/places/\` and on \`/places/<slug>/\` detail pages (Leaflet ranges through z-index 200-1000 by default via the \`.leaflet-*\` control classes)
- the four highlight boxes on the front page (custom 1500-1600 range in \`_overrides.scss\`)

Net effect: the cookie consent prompt is sandwiched and the user can't click "Accept" because the map clicks through to Leaflet controls instead.

## Fix
One-line CSS rule in \`_overrides.scss\`:

\`\`\`scss
#cookiebannerModal {
  z-index: 9999;
}
\`\`\`

Sits safely above the existing 1500-1630 range the project uses for its own modal stack.

## Test plan
- [ ] CI green
- [ ] After hard-reload: cookie banner appears on top on /, on /places/, on any /places/<slug>/ — both "Accept" and "Decline" buttons clickable