### PR TITLE
bugfix(persons): memory-harden enrich_persons_from_wikidata

### DIFF
--- a/home/management/commands/enrich_persons_from_wikidata.py
+++ b/home/management/commands/enrich_persons_from_wikidata.py
@@ -42,6 +42,7 @@ Run pattern (same shape as enrich_cities_from_wikidata):
 from __future__ import annotations
 
 import csv
+import gc
 import json
 import re
 import time
@@ -180,12 +181,29 @@ class Command(BaseCommand):
             f"margin={options['margin']})"
         )
 
-        session = requests.Session()
-        session.headers["User-Agent"] = USER_AGENT
+        # Recycle the session every ~50 persons. Previous runs
+        # died silently after 100-170 rows with no Python
+        # traceback -- best guess: requests.Session keeps a TCP
+        # pool + reads accumulating response bodies that the
+        # garbage collector doesn't free aggressively enough on
+        # its own when each Wikidata entity payload is large.
+        # Closing the session forces the pool to drain.
+        SESSION_RESET_EVERY = 50
+
+        def _new_session():
+            s = requests.Session()
+            s.headers["User-Agent"] = USER_AGENT
+            return s
+
+        session = _new_session()
 
         rows = []
         applied = 0
         for idx, p in enumerate(persons, 1):
+            if idx > 1 and (idx - 1) % SESSION_RESET_EVERY == 0:
+                session.close()
+                session = _new_session()
+                gc.collect()
             scored, signal_source = self._match_one(
                 session, p,
                 limit_candidates=options["limit_candidates"],


### PR DESCRIPTION
## Summary
Previous Person sweeps died silently after 100-170 rows (no traceback, parent shell reported exit 0). Best read of the symptoms: \`requests.Session\` keeps a TCP pool + last response bodies; the per-entity Wikidata payload for famous persons can be hundreds of KB, the GC doesn't reclaim aggressively enough between rows, and the container's OOM-guardian eventually SIGKILLs the python process.

## Fix
1. Close + reopen the \`requests.Session\` every 50 rows (constant \`SESSION_RESET_EVERY\` for easy tuning).
2. Call \`gc.collect()\` right after the reset.

## Verified
- Full sweep across all **1727** unanchored persons now runs end-to-end
- 1 auto-anchor (Abraham Joseph Menz → Q55603100), 1726 manual review
- Previous attempts never made it past row ~170

## Test plan
- [ ] CI green (42 tests still pass)
- [ ] Smoke: \`python manage.py enrich_persons_from_wikidata --limit 100 --delay 0.2\` finishes cleanly