### PR TITLE
feature(merge): merged_into filters + public-site redirect

### DIFF
--- a/home/management/commands/enrich_persons_from_wikidata.py
+++ b/home/management/commands/enrich_persons_from_wikidata.py
@@ -166,6 +166,7 @@ class Command(BaseCommand):
             .filter(
                 live=True,
                 entity_type="person",
+                merged_into__isnull=True,
             )
             .filter(wikidata_id__in=("", None))
             .order_by("pref_label")

--- a/home/management/commands/export_wikidata_quickstatements.py
+++ b/home/management/commands/export_wikidata_quickstatements.py
@@ -240,7 +240,12 @@ class Command(BaseCommand):
     def _emit_persons(self, lines, base, retrieved):
         count = 0
         wikidata_field_present = hasattr(Person, "wikidata_id")
-        qs = Person.objects.filter(live=True)
+        qs = Person.objects.filter(
+            live=True,
+            merged_into__isnull=True,
+        )
+        if hasattr(Person, "entity_type"):
+            qs = qs.filter(entity_type="person")
         if wikidata_field_present:
             qs = qs.exclude(wikidata_id="")
         else:
@@ -298,7 +303,7 @@ class Command(BaseCommand):
     def _emit_cities(self, lines, base, retrieved):
         count = 0
         for c in (
-            City.objects.filter(live=True)
+            City.objects.filter(live=True, merged_into__isnull=True)
             .exclude(wikidata_id="")
             .iterator(chunk_size=200)
         ):

--- a/home/management/commands/generate_beacons.py
+++ b/home/management/commands/generate_beacons.py
@@ -157,11 +157,14 @@ class Command(BaseCommand):
             .exclude(**{attr: ""})
             .order_by(attr)
         )
-        # Restrict Person rows to actual humans -- organizations
-        # use different authority-record families and shouldn't be
-        # advertised against, say, GND-Tp.
+        # Restrict Person rows to actual humans (skip organisations)
+        # AND to non-merged rows -- when a duplicate has been
+        # soft-merged into a canonical, only the canonical should
+        # advertise the back-link.
         if model is Person and hasattr(model, "entity_type"):
             qs = qs.filter(entity_type="person")
+        if model is Person and hasattr(model, "merged_into"):
+            qs = qs.filter(merged_into__isnull=True)
         # Restrict City rows to live + non-merged ones so merged
         # alternate rows (Pressburg -> Bratislava) don't show up
         # alongside their canonical.

--- a/home/views.py
+++ b/home/views.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from django.db.models import Prefetch, Q
 from django.http import Http404, HttpResponse
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import render, get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.utils.text import slugify
 from django.views.decorators.cache import cache_page
@@ -225,6 +225,15 @@ def person_detail_view(request, slug):
     if person is None:
         raise Http404("Person not found")
 
+    # Soft-merge redirect: a duplicate row links to its canonical
+    # via merged_into. The detail page for the duplicate 301s to
+    # the canonical so search engines and bookmarks consolidate.
+    if person.merged_into_id and person.merged_into.slug:
+        return redirect(
+            "person-detail", slug=person.merged_into.slug,
+            permanent=True,
+        )
+
     books_by_role: dict[str, list[Book]] = defaultdict(list)
     for ba in (
         BookAuthor.objects
@@ -332,6 +341,13 @@ def place_detail_view(request, slug):
     Detail view of a city, addressed by slug.
     """
     city = get_object_or_404(City, slug=slug, live=True)
+
+    # Soft-merge redirect (mirrors person_detail_view).
+    if city.merged_into_id and city.merged_into.slug:
+        return redirect(
+            "place-detail", slug=city.merged_into.slug,
+            permanent=True,
+        )
 
     geolocation = Geolocation.objects.filter(city=city).first()
 


### PR DESCRIPTION
## Summary
Follow-up to **PR #148** (\`Person.merged_into\`) + **PR #142** (\`City.merged_into\`). Wires the soft-merge pointer into the rest of the pipeline so duplicate rows are correctly hidden in every consumer:

1. \`enrich_persons_from_wikidata\` — skip Person rows whose \`merged_into\` is set.
2. \`generate_beacons\` — same filter on Person (City branch already had it).
3. \`export_wikidata_quickstatements\` — same filter on Person (+ entity_type=person guard) and on City.
4. **Public-site soft-redirect**: \`person_detail_view\` and \`place_detail_view\` issue a permanent 301 to the canonical slug when \`merged_into\` is set. Search engines + bookmarks consolidate.

## Test plan
- [ ] CI green (42 tests still pass)
- [ ] After marking a Person as merged_into a canonical, /persons/<duplicate-slug>/ 301-redirects to /persons/<canonical-slug>/
- [ ] Same for /places/<slug>/
- [ ] Next \`generate_beacons\` / QS run emits one entry per canonical, not duplicates